### PR TITLE
Add admin route navigation from auth popup

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,12 @@
+export default function AdminPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white flex items-center justify-center">
+      <div className="text-center space-y-4">
+        <h1 className="text-3xl font-semibold">Admin Dashboard</h1>
+        <p className="text-neutral-300">
+          Добро пожаловать! Здесь будет панель администратора.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/components/AuthPopup.tsx
+++ b/src/components/AuthPopup.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { useAuthRoutes } from '@/hooks/useAuthRoutes';
+
 type Props = {
   open: boolean;
   onClose: () => void;
@@ -26,6 +28,7 @@ export default function AuthPopup({
   ],
 }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const { goToAdmin } = useAuthRoutes();
 
   // Закрытие по Esc
   useEffect(() => {
@@ -102,7 +105,10 @@ export default function AuthPopup({
               <div className="mx-auto mt-6 flex max-w-md flex-col gap-4">
                 {/* Google */}
                 <button
-                  onClick={onGoogle}
+                  onClick={() => {
+                    onGoogle?.();
+                    goToAdmin();
+                  }}
                   className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-neutral-800 px-6 py-4 text-lg font-medium ring-1 ring-white/10 hover:bg-neutral-700 active:scale-[.995] transition"
                 >
                   <svg viewBox="0 0 48 48" className="size-5" aria-hidden="true">
@@ -113,7 +119,10 @@ export default function AuthPopup({
 
                 {/* Apple */}
                 <button
-                  onClick={onApple}
+                  onClick={() => {
+                    onApple?.();
+                    goToAdmin();
+                  }}
                   className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-neutral-800 px-6 py-4 text-lg font-medium ring-1 ring-white/10 hover:bg-neutral-700 active:scale-[.995] transition"
                 >
                   <svg viewBox="0 0 24 24" className="size-5" fill="currentColor" aria-hidden="true">

--- a/src/hooks/useAuthRoutes.ts
+++ b/src/hooks/useAuthRoutes.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function useAuthRoutes() {
+  const router = useRouter();
+
+  const goToAdmin = useCallback(() => {
+    router.push('/admin');
+  }, [router]);
+
+  return {
+    goToAdmin,
+  };
+}


### PR DESCRIPTION
## Summary
- navigate to the admin route whenever Google or Apple authentication buttons are pressed in the auth popup
- keep existing custom handlers for the auth buttons and add a default redirect to `/admin`
- add a simple admin page placeholder for the `/admin` route
- extract auth popup route handling into a dedicated `useAuthRoutes` hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d264ca36c88333b2387699348b9d1c