### PR TITLE
Fix admin layouts scroll behavior

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -35,11 +35,11 @@ export default function ChatPage() {
   return (
     <AppShell>
       {/* весь экран, внешняя прокрутка отключена */}
-      <div className="overflow-hidden">
+      <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
         <GradientOrbs />
 
         {/* три строки: Header / Messages(scroll) / Input */}
-        <div className="mx-auto grid h-full w-full max-w-3xl grid-rows-[auto,1fr,auto] px-4 pt-4 pb-4 gap-y-6">
+        <div className="relative z-10 mx-auto grid h-full w-full max-w-3xl flex-1 grid-rows-[auto,1fr,auto] gap-y-6 px-4 pt-4 pb-4">
           {/* 1) ШАПКА — статично */}
           <HeaderProfile
             title="Angelina"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -42,11 +42,13 @@ export default function Landing() {
   return (
     <AppShell>
       {/* любой контент справа */}
-      <div className="p-0 m-0 h-full overflow-y-auto">
-      <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
-      <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
-      <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
-      <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex-1 overflow-y-auto">
+          <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
+          <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
+          <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
+          <CardRailTwoRows items={data} className="mx-auto max-w-[1400px]" />
+        </div>
       </div>
     </AppShell>
   )

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -142,7 +142,7 @@ export default function AppShell({
                     <div className="text-sm text-white/50">Right content header</div>
                 </div>
 
-                <div className="p-4 md:p-6">{children}</div>
+                <div className="flex h-full min-h-0 flex-col p-4 md:p-6">{children}</div>
             </main>
         </div>
     );


### PR DESCRIPTION
## Summary
- ensure AppShell content wrapper stretches to full height so pages can manage their own scroll areas
- update admin landing to scroll card rails inside the content column instead of the whole layout
- adjust admin chat layout so only the message column scrolls while background decorations stay fixed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d280d55df48333a93d6a0b087db3d6