### PR TITLE
Refactor navigation links to use centralized routes

### DIFF
--- a/src/app/admin/chats/page.tsx
+++ b/src/app/admin/chats/page.tsx
@@ -1,14 +1,18 @@
+'use client';
+
 import Image from "next/image";
 import Link from "next/link";
 
 import AppShell from "@/components/AppShell";
+import { useAuthRoutes } from "@/hooks/useAuthRoutes";
+import type { AuthRouteKey } from "@/hooks/useAuthRoutes";
 
 type ChatThread = {
   id: number;
   name: string;
   preview: string;
   timestamp: string;
-  href: string;
+  routeKey: AuthRouteKey;
   avatar?: {
     src: string;
     alt?: string;
@@ -21,7 +25,7 @@ const chatThreads: ChatThread[] = [
     name: "Angelina",
     preview: "I'll wait for you at the bar. Don't keep me waiting 💋",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
     avatar: { src: "/img/mizuhara.png", alt: "Angelina" },
   },
   {
@@ -29,49 +33,49 @@ const chatThreads: ChatThread[] = [
     name: "Sabine",
     preview: "I'm homeless, I've lost my job, and I have nowhere else to go...",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 3,
     name: "Peta",
     preview: "I don't know what you're talking about, I really don't...",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 4,
     name: "Ginger",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 5,
     name: "Lisa",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 6,
     name: "Margerett",
     preview: "Well I'm not sure if that's a good idea, I have doubts...",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 7,
     name: "Sgt. Layla Smith",
     preview: "Are you aware of the speed limit in this area, sir?",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 8,
     name: "Angelina",
     preview: "I'll wait for you at the bar. Don't keep me waiting 💋",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
     avatar: { src: "/img/mizuhara.png", alt: "Angelina" },
   },
   {
@@ -79,49 +83,49 @@ const chatThreads: ChatThread[] = [
     name: "Sabine",
     preview: "I'm homeless, I've lost my job, and I have nowhere else to go...",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 10,
     name: "Peta",
     preview: "I don't know what you're talking about, I really don't...",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 11,
     name: "Ginger",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 12,
     name: "Lisa",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 13,
     name: "Margerett",
     preview: "Well I'm not sure if that's a good idea, I have doubts...",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 14,
     name: "Sgt. Layla Smith",
     preview: "Are you aware of the speed limit in this area, sir?",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 15,
     name: "Angelina",
     preview: "I'll wait for you at the bar. Don't keep me waiting 💋",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
     avatar: { src: "/img/mizuhara.png", alt: "Angelina" },
   },
   {
@@ -129,46 +133,47 @@ const chatThreads: ChatThread[] = [
     name: "Sabine",
     preview: "I'm homeless, I've lost my job, and I have nowhere else to go...",
     timestamp: "Yesterday",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 17,
     name: "Peta",
     preview: "I don't know what you're talking about, I really don't...",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 18,
     name: "Ginger",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Sat",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 19,
     name: "Lisa",
     preview: "That's not the point. You're not listening to me.",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 20,
     name: "Margerett",
     preview: "Well I'm not sure if that's a good idea, I have doubts...",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
   {
     id: 21,
     name: "Sgt. Layla Smith",
     preview: "Are you aware of the speed limit in this area, sir?",
     timestamp: "Fri",
-    href: "/admin/chat",
+    routeKey: "adminChat",
   },
 ];
 
 export default function ChatsPage() {
+  const { routes } = useAuthRoutes();
   return (
     <AppShell>
       <div className="flex-1 overflow-y-auto px-4 pb-28 pt-4 md:px-8 md:pb-12 md:pt-8">
@@ -185,7 +190,7 @@ export default function ChatsPage() {
               {chatThreads.map((thread) => (
                 <li key={thread.id}>
                   <Link
-                    href={thread.href}
+                    href={routes[thread.routeKey]}
                     className="group flex w-full items-center gap-4 py-2 transition hover:bg-white/10"
                   >
                     <ChatAvatar name={thread.name} avatar={thread.avatar} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,40 +1,52 @@
 'use client';
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ArrowRight, Mic, Sparkles, Shield, Globe2, PlayCircle, CheckCircle2, X } from "lucide-react";
 import LandingClient from '@/components/LandingClient';
 import DeviceMockup from '@/components/DeviceMockup';
 import CardRailTwoRows from "@/components/CardRailTwoRows";
 import AuthPopup from "@/components/AuthPopup";
+import { useAuthRoutes } from "@/hooks/useAuthRoutes";
+import type { AuthRouteKey } from "@/hooks/useAuthRoutes";
 
 // export const metadata = {
 //   title: 'AI Pair — Talk with an AI companion',
 // }
 
-const data = [
-  { id: 0, cardWidth: "200", src: '/img/mizuhara.png', title: 'aiAgent α', views: 'New', hoverText: 'Meet the undercover strategist.', href: '/profile/ai-agent' },
-  { id: 1, cardWidth: "200", src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 2, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 3, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 4, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 5, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 6, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 7, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 8, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 9, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 10, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 11, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 12, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 13, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 14, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 15, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 16, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 17, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 18, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 19, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 20, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
-  { id: 21, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/chat/emily' },
-  { id: 22, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/chat/tristan' },
+type CardItem = {
+  id: number;
+  cardWidth?: string;
+  src: string;
+  title: string;
+  views: string;
+  hoverText: string;
+  routeKey: AuthRouteKey;
+};
+
+const baseCardData: CardItem[] = [
+  { id: 0, cardWidth: "200", src: '/img/mizuhara.png', title: 'aiAgent α', views: 'New', hoverText: 'Meet the undercover strategist.', routeKey: 'aiAgentProfile' },
+  { id: 1, cardWidth: "200", src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 2, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 3, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 4, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 5, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 6, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 7, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 8, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 9, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 10, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 11, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 12, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 13, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 14, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 15, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 16, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 17, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 18, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 19, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 20, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
+  { id: 21, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
+  { id: 22, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
   // ...добавляй дальше сколько нужно
 ];
 
@@ -67,8 +79,17 @@ const GradientBlob = ({ className = "" }: { className?: string }) => (
 );
 
 export default function Landing() {
+  const { routes } = useAuthRoutes();
   const [open, setOpen] = useState(false);
   const [showMobileBanner, setShowMobileBanner] = useState(true);
+  const cardItems = useMemo(
+    () =>
+      baseCardData.map(({ routeKey, ...rest }) => ({
+        ...rest,
+        href: routes[routeKey],
+      })),
+    [routes],
+  );
 
   return (
     <div className="min-h-screen bg-neutral-950 text-white">
@@ -81,17 +102,17 @@ export default function Landing() {
             <div className="text-sm text-white/70">by <span className="font-semibold text-white">Freudly‑style</span></div>
           </div>
           <div className="hidden gap-6 text-sm text-white/80 md:flex">
-            <a href="/profile/ai-agent" className="hover:text-white">aiAgent α</a>
-            <a href="#features" className="hover:text-white">Features</a>
-            <a href="#demo" className="hover:text-white">Demo</a>
-            <a href="#pricing" className="hover:text-white">Pricing</a>
-            <a href="#faq" className="hover:text-white">FAQ</a>
+            <a href={routes.aiAgentProfile} className="hover:text-white">aiAgent α</a>
+            <a href={routes.landingFeatures} className="hover:text-white">Features</a>
+            <a href={routes.landingDemo} className="hover:text-white">Demo</a>
+            <a href={routes.landingPricing} className="hover:text-white">Pricing</a>
+            <a href={routes.landingFaq} className="hover:text-white">FAQ</a>
           </div>
           <div className="flex items-center gap-3">
             <button onClick={() => setOpen(true)} className="hidden rounded-xl border border-white/15 px-4 py-2 text-sm text-white/90 hover:bg-white/5 md:inline">
               Sign in
             </button>
-            <a className="inline-flex items-center gap-2 rounded-xl bg-[#6f2da8] px-4 py-2 text-sm font-medium text-white hover:opacity-90" href="#cta">
+            <a className="inline-flex items-center gap-2 rounded-xl bg-[#6f2da8] px-4 py-2 text-sm font-medium text-white hover:opacity-90" href={routes.landingCta}>
               Try it free <ArrowRight className="h-4 w-4" />
             </a>
           </div>
@@ -112,11 +133,11 @@ export default function Landing() {
               A simplified, fast landing inspired by Talkie. Speak naturally, get instant responses, and feel supported—anytime, anywhere.
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <a href="#cta" className="inline-flex items-center gap-2 rounded-2xl bg-[#6f2da8] px-5 py-3 text-sm font-semibold hover:opacity-90">
+              <a href={routes.landingCta} className="inline-flex items-center gap-2 rounded-2xl bg-[#6f2da8] px-5 py-3 text-sm font-semibold hover:opacity-90">
                 Start free
                 <ArrowRight className="h-4 w-4" />
               </a>
-              <a href="#demo" className="inline-flex items-center gap-2 rounded-2xl border border-white/15 px-5 py-3 text-sm font-semibold hover:bg-white/5">
+              <a href={routes.landingDemo} className="inline-flex items-center gap-2 rounded-2xl border border-white/15 px-5 py-3 text-sm font-semibold hover:bg-white/5">
                 <PlayCircle className="h-4 w-4" /> Watch demo
               </a>
               <Pill><Mic className="h-3.5 w-3.5" /> No signup required</Pill>
@@ -141,7 +162,7 @@ export default function Landing() {
       </Section>
 
       <main className=" text-white p-6">
-        <CardRailTwoRows items={data} className="mx-auto max-w-[1200px]" />
+        <CardRailTwoRows items={cardItems} className="mx-auto max-w-[1200px]" />
       </main>
 
 
@@ -177,7 +198,7 @@ export default function Landing() {
               ))}
             </ul>
             <div className="mt-8">
-              <a href="#pricing" className="inline-flex items-center gap-2 rounded-xl border border-white/15 px-4 py-2 text-sm hover:bg-white/5">
+              <a href={routes.landingPricing} className="inline-flex items-center gap-2 rounded-xl border border-white/15 px-4 py-2 text-sm hover:bg-white/5">
                 View pricing <ArrowRight className="h-4 w-4" />
               </a>
             </div>
@@ -204,6 +225,7 @@ export default function Landing() {
             price="$0"
             features={["5 min/day", "Core voices", "Web access"]}
             cta="Try now"
+            href={routes.landingCta}
           />
           <Plan
             highlight
@@ -211,12 +233,14 @@ export default function Landing() {
             price="$9/mo"
             features={["Unlimited talk", "Premium voices", "Priority latency"]}
             cta="Upgrade"
+            href={routes.landingCta}
           />
           <Plan
             name="Pro"
             price="$19/mo"
             features={["Everything in Plus", "Memory opt‑in", "Early features"]}
             cta="Go Pro"
+            href={routes.landingCta}
           />
         </div>
       </Section>
@@ -250,10 +274,10 @@ export default function Landing() {
             <h3 className="text-2xl font-extrabold tracking-tight">Ready to talk?</h3>
             <p className="mt-2 text-white/90">Open the mic and try a 30‑second conversation. No email required.</p>
             <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-              <a href="#" className="inline-flex items-center gap-2 rounded-2xl bg-neutral-950 px-5 py-3 text-sm font-semibold hover:bg-neutral-900">
+              <a href={routes.placeholder} className="inline-flex items-center gap-2 rounded-2xl bg-neutral-950 px-5 py-3 text-sm font-semibold hover:bg-neutral-900">
                 Open in browser <ArrowRight className="h-4 w-4" />
               </a>
-              <a href="#" className="inline-flex items-center gap-2 rounded-2xl border border-white/20 px-5 py-3 text-sm font-semibold hover:bg-white/10">
+              <a href={routes.placeholder} className="inline-flex items-center gap-2 rounded-2xl border border-white/20 px-5 py-3 text-sm font-semibold hover:bg-white/10">
                 Get the app
               </a>
             </div>
@@ -269,9 +293,9 @@ export default function Landing() {
             <span>© {new Date().getFullYear()} AI Pair</span>
           </div>
           <div className="flex items-center gap-6">
-            <a href="#" className="hover:text-white">Privacy</a>
-            <a href="#" className="hover:text-white">Terms</a>
-            <a href="#" className="hover:text-white">Contact</a>
+            <a href={routes.privacy} className="hover:text-white">Privacy</a>
+            <a href={routes.terms} className="hover:text-white">Terms</a>
+            <a href={routes.contact} className="hover:text-white">Contact</a>
           </div>
         </Section>
       </footer>
@@ -301,7 +325,7 @@ export default function Landing() {
               <span className="text-xs text-white/60">For full features and a superior experience.</span>
             </div>
             <a
-              href="#"
+              href={routes.placeholder}
               className="inline-flex items-center rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 shadow-sm hover:bg-white/90"
             >
               Get
@@ -326,7 +350,7 @@ function Feature({ icon, title, desc }: { icon: React.ReactNode; title: string; 
   );
 }
 
-function Plan({ name, price, features, cta, highlight }: { name: string; price: string; features: string[]; cta: string; highlight?: boolean }) {
+function Plan({ name, price, features, cta, highlight, href }: { name: string; price: string; features: string[]; cta: string; highlight?: boolean; href: string }) {
   return (
     <div className={`relative rounded-2xl border p-6 ${highlight ? "border-[#6f2da8] bg-[#6f2da8]/5" : "border-white/10 bg-neutral-900/60"}`}>
       {highlight && <span className="absolute -top-2 right-4 rounded-full bg-[#6f2da8] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">Popular</span>}
@@ -340,7 +364,7 @@ function Plan({ name, price, features, cta, highlight }: { name: string; price: 
           <li key={f} className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4" /> {f}</li>
         ))}
       </ul>
-      <a href="#cta" className={`mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold ${highlight ? "bg-[#6f2da8] text-white hover:opacity-90" : "border border-white/15 text-white hover:bg-white/5"}`}>
+      <a href={href} className={`mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold ${highlight ? "bg-[#6f2da8] text-white hover:opacity-90" : "border border-white/15 text-white hover:bg-white/5"}`}>
         {cta}
       </a>
     </div>

--- a/src/app/profile/ai-agent/page.tsx
+++ b/src/app/profile/ai-agent/page.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import Image from "next/image";
 import Link from "next/link";
 import { Share2, MessageCircle, UserPlus, ShieldCheck, Sparkles, Clock, Info } from "lucide-react";
 import AppShell from "@/components/AppShell";
+import { useAuthRoutes } from "@/hooks/useAuthRoutes";
 
 const highlights = [
   {
@@ -38,6 +41,7 @@ const openings = [
 ];
 
 export default function AiAgentProfilePage() {
+  const { routes } = useAuthRoutes();
   return (
     <AppShell>
       <div className="relative min-h-screen bg-neutral-950 text-white overflow-y-auto">
@@ -70,7 +74,7 @@ export default function AiAgentProfilePage() {
               </div>
               <div className="flex items-center gap-3 self-start md:self-center">
                 <Link
-                  href="/"
+                  href={routes.home}
                   className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/10"
                 >
                   Discover more
@@ -93,8 +97,8 @@ export default function AiAgentProfilePage() {
                 <UserPlus className="size-4" />
                 Follow
               </button>
-              <Link
-                href="/admin/chat"
+                <Link
+                  href={routes.adminChat}
                 className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5"
               >
                 <MessageCircle className="size-4" />

--- a/src/app/profile/user/page.tsx
+++ b/src/app/profile/user/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -15,6 +17,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 
 import AppShell from "@/components/AppShell";
+import { useAuthRoutes } from "@/hooks/useAuthRoutes";
 
 const badges = ["Narrative tactician", "Keeps secrets", "Loyal to the core"];
 
@@ -101,6 +104,7 @@ const talkies: TalkieCard[] = [
 ];
 
 export default function UserProfilePage() {
+  const { routes } = useAuthRoutes();
   return (
     <AppShell>
       <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
@@ -177,7 +181,7 @@ export default function UserProfilePage() {
                     </div>
                   </div>
                   <Link
-                    href="/admin/chat"
+                    href={routes.adminChat}
                     className="inline-flex items-center gap-2 rounded-2xl border border-white/15 px-5 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/10"
                   >
                     Message Keyser

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import {
     UserRound,
     PlusCircle,
 } from 'lucide-react';
+import { useAuthRoutes } from '@/hooks/useAuthRoutes';
 import ProfileSection from './ProfileSection';
 
 type AppShellProps = {
@@ -29,6 +30,7 @@ export default function AppShell({
 }: AppShellProps) {
     const [open, setOpen] = useState(true);
     const [mobileOpen, setMobileOpen] = useState(false);
+    const { routes } = useAuthRoutes();
 
     // восстановим состояние свёрнутости между перезагрузками
     useEffect(() => {
@@ -69,20 +71,20 @@ export default function AppShell({
 
                 {/* содержимое меню; при необходимости можно дать собственный вертикальный скролл */}
                 <nav className="mt-2 flex-1 px-2">
-                    <NavItem href="#" label="Discover" icon={<Home className="size-5" />} open={open} />
+                    <NavItem href={routes.discover} label="Discover" icon={<Home className="size-5" />} open={open} />
                     <NavItem
-                        href="/create"
+                        href={routes.createAgent}
                         label="Create aiAgent"
                         icon={<PlusCircle className="size-5" />}
                         open={open}
                     />
-                    <NavItem href="/profile/ai-agent" label="aiAgent α" icon={<MessageSquare className="size-5" />} open={open} />
-                    <NavItem href="/profile/user" label="Keyser Soze" icon={<UserRound className="size-5" />} open={open} />
+                    <NavItem href={routes.aiAgentProfile} label="aiAgent α" icon={<MessageSquare className="size-5" />} open={open} />
+                    <NavItem href={routes.userProfile} label="Keyser Soze" icon={<UserRound className="size-5" />} open={open} />
                     <div className="mt-4 border-t border-white/5 pt-3" />
                     <SectionTitle open={open}>Chats</SectionTitle>
-                    <NavItem href="#" label="Sabine" icon={<MessageSquare className="size-5" />} open={open} />
-                    <NavItem href="#" label="Peta" icon={<MessageSquare className="size-5" />} open={open} />
-                    <NavItem href="#" label="Ginger" icon={<MessageSquare className="size-5" />} open={open} />
+                    <NavItem href={routes.adminChat} label="Sabine" icon={<MessageSquare className="size-5" />} open={open} />
+                    <NavItem href={routes.adminChat} label="Peta" icon={<MessageSquare className="size-5" />} open={open} />
+                    <NavItem href={routes.adminChat} label="Ginger" icon={<MessageSquare className="size-5" />} open={open} />
                 </nav>
 
                 <div className="mt-4 border-t border-white/5 pt-3" />
@@ -143,23 +145,23 @@ export default function AppShell({
                                 </button>
                             </div>
                             <nav className="space-y-1">
-                                <NavItem href="#" label="Discover" icon={<Home className="size-5" />} open />
+                                <NavItem href={routes.discover} label="Discover" icon={<Home className="size-5" />} open />
                                 <NavItem
-                                    href="/create"
+                                    href={routes.createAgent}
                                     label="Create aiAgent"
                                     icon={<PlusCircle className="size-5" />}
                                     open
                                 />
-                                <NavItem href="/profile/ai-agent" label="aiAgent α" icon={<MessageSquare className="size-5" />} open />
-                                <NavItem href="/profile/user" label="Keyser Soze" icon={<UserRound className="size-5" />} open />
-                                <NavItem href="#" label="Search" icon={<Search className="size-5" />} open />
-                                <NavItem href="#" label="Memory" icon={<Archive className="size-5" />} open />
-                                <NavItem href="#" label="Notification" icon={<Bell className="size-5" />} open />
+                                <NavItem href={routes.aiAgentProfile} label="aiAgent α" icon={<MessageSquare className="size-5" />} open />
+                                <NavItem href={routes.userProfile} label="Keyser Soze" icon={<UserRound className="size-5" />} open />
+                                <NavItem href={routes.placeholder} label="Search" icon={<Search className="size-5" />} open />
+                                <NavItem href={routes.placeholder} label="Memory" icon={<Archive className="size-5" />} open />
+                                <NavItem href={routes.placeholder} label="Notification" icon={<Bell className="size-5" />} open />
                                 <div className="mt-4 border-t border-white/5 pt-3" />
                                 <SectionTitle open>Chats</SectionTitle>
-                                <NavItem href="#" label="Sabine" icon={<MessageSquare className="size-5" />} open />
-                                <NavItem href="#" label="Peta" icon={<MessageSquare className="size-5" />} open />
-                                <NavItem href="#" label="Ginger" icon={<MessageSquare className="size-5" />} open />
+                                <NavItem href={routes.adminChat} label="Sabine" icon={<MessageSquare className="size-5" />} open />
+                                <NavItem href={routes.adminChat} label="Peta" icon={<MessageSquare className="size-5" />} open />
+                                <NavItem href={routes.adminChat} label="Ginger" icon={<MessageSquare className="size-5" />} open />
                             </nav>
 
                             <div className="mt-4">
@@ -184,19 +186,19 @@ export default function AppShell({
             {/* ==== МОБИЛЬНОЕ НИЖНЕЕ МЕНЮ ==== */}
             <nav className="fixed inset-x-0 bottom-0 z-30 flex justify-around border-t border-white/10 bg-neutral-950/90 py-3 backdrop-blur md:hidden">
                 <Link
-                    href="/"
+                    href={routes.home}
                     className="flex flex-col items-center text-xs text-white/70"
                 >
                     <Home className="size-6" />
                 </Link>
                 <Link
-                    href="/create"
+                    href={routes.createAgent}
                     className="flex flex-col items-center text-xs text-white/70"
                 >
                     <PlusCircle className="size-6" />
                 </Link>
                 <Link
-                    href="/admin/chats"
+                    href={routes.adminChats}
                     className="flex flex-col items-center text-xs text-white/70"
                 >
                     <MessageSquare className="size-6" />

--- a/src/components/AuthPopup.tsx
+++ b/src/components/AuthPopup.tsx
@@ -28,7 +28,7 @@ export default function AuthPopup({
   ],
 }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
-  const { goToAdmin } = useAuthRoutes();
+  const { routes, goToAdmin } = useAuthRoutes();
 
   // Закрытие по Esc
   useEffect(() => {
@@ -134,8 +134,8 @@ export default function AuthPopup({
 
               <p className="mt-6 text-center text-sm text-neutral-400">
                 By continuing, you agree to Talkie’s{' '}
-                <a className="underline hover:text-white" href="#">Terms of Service</a> and{' '}
-                <a className="underline hover:text-white" href="#">Privacy Policy</a>.
+                <a className="underline hover:text-white" href={routes.terms}>Terms of Service</a> and{' '}
+                <a className="underline hover:text-white" href={routes.privacy}>Privacy Policy</a>.
               </p>
             </div>
           </motion.div>

--- a/src/hooks/useAuthRoutes.ts
+++ b/src/hooks/useAuthRoutes.ts
@@ -3,14 +3,48 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 
+const ROUTES = {
+  home: '/',
+  discover: '/',
+  createAgent: '/create',
+  aiAgentProfile: '/profile/ai-agent',
+  userProfile: '/profile/user',
+  adminRoot: '/admin',
+  adminChats: '/admin/chats',
+  adminChat: '/admin/chat',
+  chatEmily: '/chat/emily',
+  chatTristan: '/chat/tristan',
+  landingFeatures: '#features',
+  landingDemo: '#demo',
+  landingPricing: '#pricing',
+  landingFaq: '#faq',
+  landingCta: '#cta',
+  terms: '#',
+  privacy: '#',
+  contact: '#',
+  placeholder: '#',
+} as const;
+
+export type AuthRoutes = typeof ROUTES;
+export type AuthRouteKey = keyof AuthRoutes;
+
 export function useAuthRoutes() {
   const router = useRouter();
 
+  const goTo = useCallback(
+    (route: AuthRouteKey) => {
+      router.push(ROUTES[route]);
+    },
+    [router],
+  );
+
   const goToAdmin = useCallback(() => {
-    router.push('/admin');
+    router.push(ROUTES.adminRoot);
   }, [router]);
 
   return {
+    routes: ROUTES,
+    goTo,
     goToAdmin,
   };
 }


### PR DESCRIPTION
## Summary
- extend `useAuthRoutes` with a canonical map of all internal and section links
- refactor navigation components and pages to consume the shared route map instead of hard-coded href strings
- ensure landing data, chat threads, and auth dialog reference the centralized routes for consistent linking

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d3986237008333a3482820d51cb06a