### PR TITLE
refactor: define styled button variants

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import AppShell from "@/components/AppShell";
 import GradientOrbs from "@/components/ui/GradientOrbs";
+import { Button } from "@/components/ui/Button";
 import HeaderProfile from "@/components/chat/HeaderProfile";
 import IntroCard from "@/components/chat/IntroCard";
 import MessageList from "@/components/chat/MessageList";
@@ -55,16 +56,26 @@ export default function ChatPage() {
             {/* быстрые чипы — тоже остаются в зоне прокрутки сообщений или вынеси выше, если хочешь фиксированно */}
             <div className="flex flex-wrap items-center gap-3">
               {[
-                { label: 'Hi', gradient: 'from-amber-200/70 to-orange-300/80' },
-                { label: '😍', gradient: 'from-rose-300/80 to-purple-400/80' },
+                {
+                  label: 'Hi',
+                  gradientFrom: 'rgba(253, 230, 138, 0.7)',
+                  gradientTo: 'rgba(253, 186, 116, 0.8)',
+                },
+                {
+                  label: '😍',
+                  gradientFrom: 'rgba(253, 164, 175, 0.8)',
+                  gradientTo: 'rgba(192, 132, 252, 0.8)',
+                },
               ].map((chip) => (
-                <button
+                <Button
                   key={chip.label}
-                  className={`rounded-2xl bg-gradient-to-br ${chip.gradient} px-4 py-2 text-sm font-semibold text-neutral-900 shadow-lg transition hover:brightness-105`}
+                  variant="gradient"
+                  gradientFrom={chip.gradientFrom}
+                  gradientTo={chip.gradientTo}
                   onClick={() => handleSend(chip.label)}
                 >
                   {chip.label}
-                </button>
+                </Button>
               ))}
             </div>
           </div>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -130,7 +130,7 @@ export default function CreateAiAgentPage() {
             {completed && (
               <div className="flex items-center gap-3 rounded-3xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
                 <CheckCircle2 className="size-5" />
-                <span>Your draft is ready! Feel free to revisit any step or publish when you're set.</span>
+                <span>Your draft is ready! Feel free to revisit any step or publish when you&rsquo;re set.</span>
               </div>
             )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import LandingClient from '@/components/LandingClient';
 import DeviceMockup from '@/components/DeviceMockup';
 import CardRailTwoRows from "@/components/CardRailTwoRows";
 import AuthPopup from "@/components/AuthPopup";
+import { Button } from "@/components/ui/Button";
 import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
 import type { AuthRouteKey } from "@/helpers/hooks/useAuthRoutes";
 
@@ -109,9 +110,11 @@ export default function Landing() {
             <a href={routes.landingFaq} className="hover:text-white">FAQ</a>
           </div>
           <div className="flex items-center gap-3">
-            <button onClick={() => setOpen(true)} className="hidden rounded-xl border border-white/15 px-4 py-2 text-sm text-white/90 hover:bg-white/5 md:inline">
-              Sign in
-            </button>
+            <div className="hidden md:inline">
+              <Button onClick={() => setOpen(true)} variant="ghostRounded">
+                Sign in
+              </Button>
+            </div>
             <a className="inline-flex items-center gap-2 rounded-xl bg-[#6f2da8] px-4 py-2 text-sm font-medium text-white hover:opacity-90" href={routes.landingCta}>
               Try it free <ArrowRight className="h-4 w-4" />
             </a>
@@ -309,14 +312,14 @@ export default function Landing() {
       {showMobileBanner && (
         <div className="fixed inset-x-0 bottom-4 z-50 px-4 md:hidden">
           <div className="mx-auto flex max-w-xl items-center gap-3 rounded-3xl border border-white/15 bg-neutral-900/95 p-3 shadow-2xl shadow-black/40 backdrop-blur">
-            <button
+            <Button
               type="button"
               onClick={() => setShowMobileBanner(false)}
-              className="flex h-8 w-8 items-center justify-center rounded-full text-white/50 hover:bg-white/10 hover:text-white"
+              variant="mobileClose"
               aria-label="Dismiss mobile banner"
             >
               <X className="h-4 w-4" />
-            </button>
+            </Button>
             <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-[#6f2da8] text-lg font-semibold text-white">
               t
             </div>

--- a/src/app/profile/ai-agent/page.tsx
+++ b/src/app/profile/ai-agent/page.tsx
@@ -3,6 +3,7 @@
 
 import Link from "next/link";
 import AppShell from "@/components/AppShell";
+import { Button } from "@/components/ui/Button";
 import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
 
 
@@ -36,7 +37,7 @@ export default function AiAgentProfilePage() {
               <HeaderCard />
               <div className="flex items-center gap-3 self-start md:self-center">
                 <Link href={routes.home} className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/10">Discover more</Link>
-                <button className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/10">Share</button>
+                <Button variant="ghostPill">Share</Button>
               </div>
             </div>
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { Button } from '@/components/ui/Button';
 import {
     Menu,
     ChevronLeft,
@@ -59,13 +60,13 @@ export default function AppShell({
             >
                 {/* верх панели */}
                 <div className="flex items-center gap-2 px-3 py-3">
-                    <button
+                    <Button
                         onClick={() => setOpen((s) => !s)}
-                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 hover:bg-white/15"
+                        variant="sidebarIcon"
                         aria-label={open ? 'Collapse' : 'Expand'}
                     >
                         {open ? <ChevronLeft /> : <Menu />}
-                    </button>
+                    </Button>
                     {open && <span className="text-lg font-semibold">talkie</span>}
                 </div>
 
@@ -98,13 +99,13 @@ export default function AppShell({
             <div className="md:hidden">
                 {/* верхняя панель с кнопкой открытия */}
                 <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b border-white/10 bg-neutral-900/90 px-3 py-3 backdrop-blur">
-                    <button
+                    <Button
                         onClick={() => setMobileOpen(true)}
-                        className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/10 hover:bg-white/15"
+                        variant="sidebarIcon"
                         aria-label="Open menu"
                     >
                         <Menu />
-                    </button>
+                    </Button>
                     <div className="flex-1">
                         <label className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2">
                             <Search className="size-4 text-white/70" aria-hidden />
@@ -136,13 +137,13 @@ export default function AppShell({
                         >
                             <div className="mb-2 flex items-center justify-between">
                                 <span className="text-lg font-semibold">Menu</span>
-                                <button
+                                <Button
                                     onClick={() => setMobileOpen(false)}
-                                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 hover:bg-white/15"
+                                    variant="sidebarIcon"
                                     aria-label="Close menu"
                                 >
                                     <ChevronLeft />
-                                </button>
+                                </Button>
                             </div>
                             <nav className="space-y-1">
                                 <NavItem href={routes.discover} label="Discover" icon={<Home className="size-5" />} open />

--- a/src/components/AuthPopup.tsx
+++ b/src/components/AuthPopup.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { Button } from '@/components/ui/Button';
 
 import { useAuthRoutes } from '@/helpers/hooks/useAuthRoutes';
 
@@ -82,15 +83,13 @@ export default function AuthPopup({
                 </div>
               ))}
               {/* Крестик */}
-              <button
-                onClick={onClose}
-                className="absolute right-3 top-3 grid size-9 place-items-center rounded-full bg-black/60 text-white/90 hover:bg-black focus:outline-none focus:ring-2 focus:ring-white/40"
-                aria-label="Close"
-              >
-                <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path strokeLinecap="round" d="M6 6l12 12M18 6L6 18" />
-                </svg>
-              </button>
+              <div className="absolute right-3 top-3">
+                <Button onClick={onClose} variant="overlayClose" aria-label="Close">
+                  <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path strokeLinecap="round" d="M6 6l12 12M18 6L6 18" />
+                  </svg>
+                </Button>
+              </div>
             </div>
 
             {/* Контент */}
@@ -104,32 +103,32 @@ export default function AuthPopup({
 
               <div className="mx-auto mt-6 flex max-w-md flex-col gap-4">
                 {/* Google */}
-                <button
+                <Button
                   onClick={() => {
                     onGoogle?.();
                     goToAdmin();
                   }}
-                  className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-neutral-800 px-6 py-4 text-lg font-medium ring-1 ring-white/10 hover:bg-neutral-700 active:scale-[.995] transition"
+                  variant="authProvider"
                 >
                   <svg viewBox="0 0 48 48" className="size-5" aria-hidden="true">
                     <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"/><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"/><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"/><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"/>
                   </svg>
                   Continue with Google
-                </button>
+                </Button>
 
                 {/* Apple */}
-                <button
+                <Button
                   onClick={() => {
                     onApple?.();
                     goToAdmin();
                   }}
-                  className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-neutral-800 px-6 py-4 text-lg font-medium ring-1 ring-white/10 hover:bg-neutral-700 active:scale-[.995] transition"
+                  variant="authProvider"
                 >
                   <svg viewBox="0 0 24 24" className="size-5" fill="currentColor" aria-hidden="true">
                     <path d="M16.36 13.46c-.03-2.36 1.93-3.49 2.02-3.55-1.1-1.6-2.83-1.82-3.43-1.85-1.46-.15-2.85.86-3.6.86-.75 0-1.9-.84-3.12-.82-1.61.02-3.1.94-3.93 2.39-1.68 2.9-.43 7.18 1.2 9.53.8 1.16 1.75 2.47 3.01 2.42 1.21-.05 1.66-.78 3.12-.78s1.86.78 3.12.76c1.29-.03 2.11-1.18 2.9-2.35.9-1.33 1.27-2.62 1.29-2.69-.03-.01-2.51-.96-2.58-3.92zM14.5 5.6c.66-.8 1.11-1.9.99-2.99-.96.04-2.12.64-2.8 1.43-.61.71-1.15 1.86-1 2.95 1.06.08 2.15-.53 2.81-1.39z"/>
                   </svg>
                   Continue with Apple
-                </button>
+                </Button>
               </div>
 
               <p className="mt-6 text-center text-sm text-neutral-400">

--- a/src/components/CardRailTwoRows.tsx
+++ b/src/components/CardRailTwoRows.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useRef } from 'react';
+import { Button } from '@/components/ui/Button';
 import HoverSwapCard from './AiCard';
 
 type Item = {
@@ -38,20 +39,16 @@ export default function CardRailTwoRows({
   return (
     <section className={`relative ${className}`}>
       {/* Кнопки пролистывания (опционально) */}
-      <button
-        aria-label="Prev"
-        onClick={() => scrollBy(-1)}
-        className="hidden md:flex absolute left-2 top-1/2 -translate-y-1/2 z-10 h-10 w-10 items-center justify-center rounded-full bg-white/90 shadow hover:bg-white"
-      >
-        ‹
-      </button>
-      <button
-        aria-label="Next"
-        onClick={() => scrollBy(1)}
-        className="hidden md:flex absolute right-2 top-1/2 -translate-y-1/2 z-10 h-10 w-10 items-center justify-center rounded-full bg-white/90 shadow hover:bg-white"
-      >
-        ›
-      </button>
+      <div className="hidden md:flex absolute left-2 top-1/2 z-10 -translate-y-1/2">
+        <Button aria-label="Prev" onClick={() => scrollBy(-1)} variant="carouselNav">
+          ‹
+        </Button>
+      </div>
+      <div className="hidden md:flex absolute right-2 top-1/2 z-10 -translate-y-1/2">
+        <Button aria-label="Next" onClick={() => scrollBy(1)} variant="carouselNav">
+          ›
+        </Button>
+      </div>
 
       {/* Сам скроллер */}
       <div

--- a/src/components/DeviceMockup.tsx
+++ b/src/components/DeviceMockup.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { motion } from 'framer-motion'
-import { ArrowRight, Mic, Sparkles, Shield, Globe2, Bot, PlayCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Mic, Bot } from "lucide-react";
 // импорт иконок, ваших Badge/Pill и т.п.
 
 function Bubble({ role, text }: { role: "ai" | "me"; text: string }) {
@@ -40,7 +41,7 @@ export default function DeviceMockup() {
                 </div>
                 <div className="mt-5 flex items-center justify-between rounded-xl border border-white/10 bg-neutral-800/60 p-3">
                   <div className="flex items-center gap-2 text-white/70"><Mic className="h-4 w-4" /> Tap and talk</div>
-                  <button className="rounded-lg bg-[#6f2da8] px-3 py-1.5 text-sm font-medium">Hold</button>
+                  <Button variant="mockup">Hold</Button>
                 </div>
               </div>
             </div>

--- a/src/components/ProfileSection.tsx
+++ b/src/components/ProfileSection.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Crown } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 
 export default function ProfileSection({ open = true }: { open?: boolean }) {
   return (
@@ -16,15 +17,10 @@ export default function ProfileSection({ open = true }: { open?: boolean }) {
         {!open ? null : (
           <div className="flex-1 flex items-center gap-2">
             {/* subscribe pill */}
-            <button
-              className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold 
-                         text-white ring-1 ring-white/10 
-                         bg-gradient-to-r from-fuchsia-400/30 via-pink-400/30 to-purple-400/30
-                         hover:from-fuchsia-400/40 hover:to-purple-400/40 transition"
-            >
+            <Button variant="subscribe">
               <Crown className="size-4" />
               <span>Subscribe</span>
-            </button>
+            </Button>
 
             {/* discount badge */}
             <div className="rounded-xl bg-purple-300/80 px-2 py-1 text-[12px] font-semibold text-purple-900">

--- a/src/components/ai-agent-create/ActionBar.tsx
+++ b/src/components/ai-agent-create/ActionBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 
 export default function ActionBar({
   canBack,
@@ -20,32 +21,34 @@ export default function ActionBar({
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex gap-3">
-        <button
+        <Button
           type="button"
           onClick={onBack}
           disabled={!canBack}
-          className="inline-flex items-center gap-2 rounded-2xl border border-white/15 px-4 py-2 text-sm text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+          variant="outline"
         >
           <ArrowLeft className="size-4" />
           Back
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
           onClick={onReset}
-          className="inline-flex items-center gap-2 rounded-2xl border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:bg-white/10"
+          variant="outlineMuted"
         >
           Start over
-        </button>
+        </Button>
       </div>
-      <button
-        type="button"
-        onClick={onNext}
-        disabled={!canNext}
-        className="inline-flex items-center gap-2 self-end rounded-2xl bg-violet-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-violet-500/30 transition hover:bg-violet-400 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {isFinal ? "Create aiAgent" : "Continue"}
-        <ArrowRight className="size-4" />
-      </button>
+      <div className="self-end">
+        <Button
+          type="button"
+          onClick={onNext}
+          disabled={!canNext}
+          variant="primaryTight"
+        >
+          {isFinal ? "Create aiAgent" : "Continue"}
+          <ArrowRight className="size-4" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/ai-agent-create/MediaKitStep.tsx
+++ b/src/components/ai-agent-create/MediaKitStep.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { ImagePlus, X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 import { GalleryItem } from "../../helpers/types/agent-create";
 
 export default function MediaKitStep({
@@ -35,7 +36,7 @@ export default function MediaKitStep({
 
       {gallery.length >= maxItems && (
         <p className="text-xs text-white/60">
-          You've reached the {maxItems}-image limit. Remove an image if you want to add a new one.
+          You&rsquo;ve reached the {maxItems}-image limit. Remove an image if you want to add a new one.
         </p>
       )}
 
@@ -43,14 +44,16 @@ export default function MediaKitStep({
         {gallery.map((item) => (
           <div key={item.id} className="group relative overflow-hidden rounded-3xl border border-white/10">
             <img src={item.preview} alt="Gallery asset" className="h-40 w-full object-cover" />
-            <button
-              type="button"
-              onClick={() => onRemove(item.id)}
-              className="absolute right-3 top-3 inline-flex size-8 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition group-hover:opacity-100"
-              aria-label="Remove image"
-            >
-              <X className="size-4" />
-            </button>
+            <div className="absolute right-3 top-3">
+              <Button
+                type="button"
+                onClick={() => onRemove(item.id)}
+                variant="galleryClose"
+                aria-label="Remove image"
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
           </div>
         ))}
         {!gallery.length && (

--- a/src/components/ai-agent/ActionButtons.tsx
+++ b/src/components/ai-agent/ActionButtons.tsx
@@ -1,22 +1,21 @@
 import Link from "next/link";
 import { MessageCircle, UserPlus, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 
 
 export default function ActionButtons({
     homeHref,
-    chatHref,
 }: {
     homeHref: string;
-    chatHref: string;
 }) {
     return (
         <div className="flex items-center gap-3 self-start md:self-center">
             <Link href={homeHref} className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/10">
                 Discover more
             </Link>
-            <button className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/10">
+            <Button variant="ghostPill">
                 <Share2 className="size-4" /> Share
-            </button>
+            </Button>
 
 
             {/* Primary CTA row */}
@@ -29,9 +28,11 @@ export default function ActionButtons({
 export function PrimaryCTAs({ chatHref }: { chatHref: string }) {
     return (
         <div className="flex flex-col gap-3 md:flex-row">
-            <button className="flex flex-1 items-center justify-center gap-2 rounded-2xl bg-violet-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-violet-500/30 transition hover:bg-violet-400">
-                <UserPlus className="size-4" /> Follow
-            </button>
+            <div className="flex flex-1">
+                <Button variant="primary">
+                    <UserPlus className="size-4" /> Follow
+                </Button>
+            </div>
             <Link href={chatHref} className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5">
                 <MessageCircle className="size-4" /> Chat with aiAgent
             </Link>

--- a/src/components/chat/HeaderProfile.tsx
+++ b/src/components/chat/HeaderProfile.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
+import { Button } from '@/components/ui/Button';
 
 
 type Props = {
@@ -36,12 +37,9 @@ export default function HeaderProfile({ title, avatarSrc, stats, onFollow }: Pro
                         </div>
                     )}
                 </div>
-                <button
-                    onClick={onFollow}
-                    className="w-fit rounded-full bg-white px-4 py-1.5 text-sm font-semibold text-neutral-900 transition hover:bg-white/90"
-                >
+                <Button onClick={onFollow} variant="solidWhitePillCompact">
                     Follow
-                </button>
+                </Button>
             </div>
         </header>
     );

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -2,6 +2,7 @@
 
 
 import React, { useState } from 'react';
+import { Button } from '@/components/ui/Button';
 
 
 type Props = {
@@ -31,12 +32,9 @@ export default function MessageInput({ placeholder = 'Say something...', onSend 
                     className="flex-1 rounded-2xl border border-white/10 bg-transparent px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
                     placeholder={placeholder}
                 />
-                <button
-                    type="submit"
-                    className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-white/90"
-                >
+                <Button type="submit" variant="solidWhite">
                     Send
-                </button>
+                </Button>
             </div>
         </form>
     );

--- a/src/components/profile/CommunityStats.tsx
+++ b/src/components/profile/CommunityStats.tsx
@@ -21,7 +21,7 @@ export default function CommunityStats() {
                     <Star className="size-6 text-amber-400" />
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-neutral-900/80 px-4 py-3 text-sm text-white/70">
-                    “Vadim's sessions feel like stepping into a movie scene you secretly hope is real.”
+                    “Vadim&rsquo;s sessions feel like stepping into a movie scene you secretly hope is real.”
                 </div>
             </div>
         </section>

--- a/src/components/profile/HeaderActions.tsx
+++ b/src/components/profile/HeaderActions.tsx
@@ -1,28 +1,29 @@
 import { ArrowLeft, MoreHorizontal, Share2, Sparkles } from "lucide-react";
+import { Button } from '@/components/ui/Button';
 
 
 export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
     return (
         <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-2">
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                <Button variant="frostedIcon">
                     <ArrowLeft className="size-5" />
-                </button>
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                </Button>
+                <Button variant="frostedIcon">
                     <Share2 className="size-5" />
-                </button>
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                </Button>
+                <Button variant="frostedIcon">
                     <MoreHorizontal className="size-5" />
-                </button>
+                </Button>
             </div>
             <div className="flex items-center gap-3">
-                <button className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-2 text-sm font-medium text-white/80 backdrop-blur transition hover:bg-white/20">
+                <Button variant="frostedPill">
                     <Sparkles className="size-4" />
                     Subscribed
-                </button>
-                <button onClick={onEdit} className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200">
+                </Button>
+                <Button onClick={onEdit} variant="solidWhitePill">
                     Edit Profile
-                </button>
+                </Button>
             </div>
         </div>
     );

--- a/src/components/profile/edit/overview/DialogHeader.tsx
+++ b/src/components/profile/edit/overview/DialogHeader.tsx
@@ -1,19 +1,21 @@
 "use client";
 
+import { Button } from "@/components/ui/Button";
+
 export default function DialogHeader({ onClose }: { onClose: () => void }) {
   return (
     <div className="flex items-center justify-between px-6 pb-4 pt-6 sm:px-8">
       <h2 className="text-xl font-semibold sm:text-2xl">Edit Profile</h2>
-      <button
+      <Button
         type="button"
         onClick={onClose}
-        className="inline-flex size-9 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition hover:bg-white/10"
+        variant="frostedIconCompact"
         aria-label="Close"
       >
         <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" d="M6 6l12 12M18 6L6 18" />
         </svg>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/profile/edit/overview/FormActions.tsx
+++ b/src/components/profile/edit/overview/FormActions.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Button } from "@/components/ui/Button";
+
 export default function FormActions({
   onCancel,
 }: {
@@ -7,19 +9,19 @@ export default function FormActions({
 }) {
   return (
     <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-      <button
+      <Button
         type="button"
         onClick={onCancel}
-        className="inline-flex items-center justify-center rounded-2xl border border-white/15 px-6 py-3 text-sm font-medium text-white/70 transition hover:bg-white/10"
+        variant="outlineWide"
       >
         Cancel
-      </button>
-      <button
+      </Button>
+      <Button
         type="submit"
-        className="inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200"
+        variant="solidWhiteWide"
       >
         Save
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,122 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes, CSSProperties } from "react";
+
+type ButtonVariant =
+  | "ghostPill"
+  | "ghostPillCompact"
+  | "frostedPill"
+  | "ghostRounded"
+  | "solidWhitePill"
+  | "solidWhitePillCompact"
+  | "solidWhite"
+  | "solidWhiteWide"
+  | "primary"
+  | "primaryTight"
+  | "outline"
+  | "outlineMuted"
+  | "outlineWide"
+  | "frostedIcon"
+  | "frostedIconCompact"
+  | "sidebarIcon"
+  | "overlayClose"
+  | "galleryClose"
+  | "authProvider"
+  | "subscribe"
+  | "carouselNav"
+  | "mockup"
+  | "mobileClose"
+  | "gradient";
+
+type BaseButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> & {
+  variant: Exclude<ButtonVariant, "gradient">;
+};
+
+type GradientButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> & {
+  variant: "gradient";
+  gradientFrom: string;
+  gradientTo: string;
+};
+
+type ButtonProps = BaseButtonProps | GradientButtonProps;
+
+const variantStyles: Record<Exclude<ButtonVariant, "gradient">, string> = {
+  ghostPill:
+    "inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 transition hover:bg-white/10",
+  ghostPillCompact:
+    "inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs uppercase tracking-wide text-white/60 transition hover:bg-white/10",
+  frostedPill:
+    "inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-2 text-sm font-medium text-white/80 backdrop-blur transition hover:bg-white/20",
+  ghostRounded:
+    "inline-flex items-center justify-center rounded-xl border border-white/15 px-4 py-2 text-sm text-white/90 transition hover:bg-white/5",
+  solidWhitePill:
+    "inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200",
+  solidWhitePillCompact:
+    "inline-flex items-center gap-2 rounded-full bg-white px-4 py-1.5 text-sm font-semibold text-neutral-900 transition hover:bg-white/90",
+  solidWhite:
+    "inline-flex items-center justify-center rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-white/90",
+  solidWhiteWide:
+    "inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200",
+  primary:
+    "inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-violet-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-violet-500/30 transition hover:bg-violet-400",
+  primaryTight:
+    "inline-flex items-center justify-center gap-2 rounded-2xl bg-violet-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-violet-500/30 transition hover:bg-violet-400 disabled:cursor-not-allowed disabled:opacity-60",
+  outline:
+    "inline-flex items-center gap-2 rounded-2xl border border-white/15 px-4 py-2 text-sm text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40",
+  outlineMuted:
+    "inline-flex items-center gap-2 rounded-2xl border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:bg-white/10",
+  outlineWide:
+    "inline-flex items-center justify-center rounded-2xl border border-white/15 px-6 py-3 text-sm font-medium text-white/70 transition hover:bg-white/10",
+  frostedIcon:
+    "inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-white transition hover:bg-white/10",
+  frostedIconCompact:
+    "inline-flex size-9 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition hover:bg-white/10",
+  sidebarIcon:
+    "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/10 text-white transition hover:bg-white/15",
+  overlayClose:
+    "grid size-9 place-items-center rounded-full bg-black/60 text-white/90 transition hover:bg-black focus:outline-none focus:ring-2 focus:ring-white/40",
+  galleryClose:
+    "inline-flex size-8 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-white/40 group-hover:opacity-100",
+  authProvider:
+    "inline-flex w-full items-center justify-center gap-3 rounded-full bg-neutral-800 px-6 py-4 text-lg font-medium text-white ring-1 ring-white/10 transition hover:bg-neutral-700 active:scale-[.995]",
+  subscribe:
+    "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-white ring-1 ring-white/10 bg-gradient-to-r from-fuchsia-400/30 via-pink-400/30 to-purple-400/30 transition hover:from-fuchsia-400/40 hover:to-purple-400/40",
+  carouselNav:
+    "inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-neutral-900 shadow transition hover:bg-white",
+  mockup:
+    "inline-flex items-center justify-center rounded-lg bg-[#6f2da8] px-3 py-1.5 text-sm font-medium text-white",
+  mobileClose:
+    "inline-flex h-8 w-8 items-center justify-center rounded-full text-white/50 transition hover:bg-white/10 hover:text-white",
+};
+
+const gradientBaseClasses =
+  "inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold text-neutral-900 shadow-lg transition hover:brightness-105";
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant, ...restProps },
+  ref,
+) {
+  if (variant === "gradient") {
+    const { children, gradientFrom, gradientTo, style, ...rest } = restProps as GradientButtonProps;
+    const backgroundImage = `linear-gradient(135deg, ${gradientFrom}, ${gradientTo})`;
+    const mergedStyle: CSSProperties = { ...style, backgroundImage };
+    return (
+      <button ref={ref} className={gradientBaseClasses} style={mergedStyle} {...rest}>
+        {children}
+      </button>
+    );
+  }
+
+  const { children, style, ...rest } = restProps as BaseButtonProps;
+  const className = variantStyles[variant];
+
+  return (
+    <button ref={ref} className={className} style={style} {...rest}>
+      {children}
+    </button>
+  );
+});
+
+Button.displayName = "Button";
+
+export { Button };
+export type { ButtonProps, ButtonVariant };

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -1,24 +1,25 @@
 import { ArrowLeft, MoreHorizontal, Share2, Sparkles } from "lucide-react";
+import { Button } from '@/components/ui/Button';
 
 
 export default function HeaderBar() {
     return (
         <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-2">
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                <Button variant="frostedIcon">
                     <ArrowLeft className="size-5" />
-                </button>
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                </Button>
+                <Button variant="frostedIcon">
                     <Share2 className="size-5" />
-                </button>
-                <button className="inline-flex size-10 items-center justify-center rounded-2xl border border-white/10 bg-white/5 hover:bg-white/10">
+                </Button>
+                <Button variant="frostedIcon">
                     <MoreHorizontal className="size-5" />
-                </button>
+                </Button>
             </div>
-            <button className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-5 py-2 text-sm font-medium text-white/80 backdrop-blur transition hover:bg-white/20">
+            <Button variant="frostedPill">
                 <Sparkles className="size-4" />
                 Subscribed
-            </button>
+            </Button>
         </div>
     );
 }

--- a/src/components/user/SectionHeader.tsx
+++ b/src/components/user/SectionHeader.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/Button';
+
 export default function SectionHeader({ title, subtitle, actionLabel }: { title: string; subtitle?: string; actionLabel?: string }) {
     return (
         <div className="flex items-end justify-between gap-4">
@@ -6,9 +8,9 @@ export default function SectionHeader({ title, subtitle, actionLabel }: { title:
                 {subtitle ? <p className="mt-1 text-sm text-white/60">{subtitle}</p> : null}
             </div>
             {actionLabel ? (
-                <button className="hidden items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs uppercase tracking-wide text-white/60 transition hover:bg-white/10 sm:flex">
-                    {actionLabel}
-                </button>
+                <div className="hidden sm:flex">
+                    <Button variant="ghostPillCompact">{actionLabel}</Button>
+                </div>
             ) : null}
         </div>
     );


### PR DESCRIPTION
## Summary
- replace the generic Button implementation with variant-based styles so Tailwind classes live inside the shared component
- update all button usages to consume the new variants and move layout-specific utilities into wrappers where needed
- encode chat quick reply gradients as color values and render them through the reusable gradient button style

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c18eb6788333b7665d9757ae53cc