### PR TITLE
Add storage helper for auth tokens

### DIFF
--- a/src/helpers/utils/storageHelper.ts
+++ b/src/helpers/utils/storageHelper.ts
@@ -1,0 +1,33 @@
+const REFRESH_TOKEN_KEY = 'REFRESH_TOKEN';
+const ACCESS_TOKEN_KEY = 'ACCESS_TOKEN';
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const storageHelper = {
+    setRefreshToken(token: string) {
+        if (!isBrowser()) return;
+        localStorage.setItem(REFRESH_TOKEN_KEY, token);
+    },
+    getRefreshToken(): string | null {
+        if (!isBrowser()) return null;
+        return localStorage.getItem(REFRESH_TOKEN_KEY);
+    },
+    removeRefreshToken() {
+        if (!isBrowser()) return;
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+    },
+    setAccessToken(token: string) {
+        if (!isBrowser()) return;
+        localStorage.setItem(ACCESS_TOKEN_KEY, token);
+    },
+    getAccessToken(): string | null {
+        if (!isBrowser()) return null;
+        return localStorage.getItem(ACCESS_TOKEN_KEY);
+    },
+    removeAccessToken() {
+        if (!isBrowser()) return;
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+    },
+};
+
+export default storageHelper;


### PR DESCRIPTION
## Summary
- add a storage helper utility to persist refresh and access tokens in localStorage
- expose helpers to set, get, and remove both token types with SSR guards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3d43b20288333b46b4aa671090b46