### PR TITLE
feat: show follower and following lists from profile card

### DIFF
--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -1,56 +1,163 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { MapPin } from "lucide-react";
 import { MyProfileDTO } from "@/helpers/types";
 import { getUserAvatar, getUserFullName } from "@/helpers/utils/user";
 import { getMonthYear, getTimeAgo } from "@/helpers/utils/date";
+import { useRootStore, useStoreData } from "@/stores/StoreProvider";
+import UserListModal from "./UserListModal";
 
+const PAGE_SIZE = 12;
+
+type ActiveModal = "followers" | "following" | null;
 
 export default function ProfileCard({ profile, genderLabel }: { profile: MyProfileDTO; genderLabel: string }) {
-    const profileAvatar = getUserAvatar(profile);
-    const userFullName = getUserFullName(profile);
+  const profileAvatar = getUserAvatar(profile);
+  const userFullName = getUserFullName(profile);
+  const followerCount = profile?.followers ?? 0;
+  const followingCount = profile?.following ?? 0;
 
-    return (
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur">
-            <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
-                <div className="flex flex-1 items-start gap-5">
-                    <div className="relative size-24 shrink-0 overflow-hidden rounded-3xl border border-white/15">
-                        <Image
-                            src={profileAvatar}
-                            alt={`${userFullName} portrait`}
-                            fill
-                            className="object-cover"
-                            sizes="(max-width: 768px) 96px, 150px"
-                        />
-                    </div>
-                    <div className="space-y-3">
-                        {/* <div className="flex items-center gap-2 text-sm text-white/60">
-                            <MapPin className="size-4 text-violet-300" />
-                            <span>Designing between worlds</span>
-                        </div> */}
-                        <div>
-                            <h1 className="text-4xl font-semibold tracking-tight">{userFullName}</h1>
-                            <p className="mt-2 text-sm leading-6 text-white/70">{profile?.userBio}</p>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-white/60">
-                            <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1">{genderLabel}</span>
-                        </div>
-                    </div>
-                </div>
-                <div className="grid w-full max-w-xs gap-4 rounded-2xl border border-white/10 bg-neutral-900/80 p-5 text-sm text-white/70">
-                    <div>
-                        <p className="text-xs uppercase tracking-wide text-white/40">Membership</p>
-                        <p className="mt-1 font-medium text-white">{profile?.role}</p>
-                    </div>
-                    <div>
-                        <p className="text-xs uppercase tracking-wide text-white/40">Joined</p>
-                        <p className="mt-1">{getMonthYear(profile?.createdAt)}</p>
-                    </div>
-                    <div>
-                        <p className="text-xs uppercase tracking-wide text-white/40">Last updated</p>
-                        <p className="mt-1">{getTimeAgo(profile?.updatedAt)}</p>
-                    </div>
-                </div>
+  const { profileStore } = useRootStore();
+  const followers = useStoreData(profileStore, (store) => store.followers);
+  const following = useStoreData(profileStore, (store) => store.following);
+  const followersHasMore = useStoreData(profileStore, (store) => store.followersHasMore);
+  const followingHasMore = useStoreData(profileStore, (store) => store.followingHasMore);
+  const isLoadingFollowers = useStoreData(profileStore, (store) => store.isLoadingFollowers);
+  const isLoadingFollowing = useStoreData(profileStore, (store) => store.isLoadingFollowing);
+
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null);
+
+  useEffect(() => {
+    if (!activeModal) return;
+
+    const params = { page: 1, limit: PAGE_SIZE };
+
+    if (activeModal === "followers") {
+      profileStore.resetFollowers();
+      void profileStore.fetchMyFollowers(params);
+    }
+
+    if (activeModal === "following") {
+      profileStore.resetFollowing();
+      void profileStore.fetchMyFollowing(params);
+    }
+  }, [activeModal, profileStore]);
+
+  const activeUsers = useMemo(() => {
+    if (activeModal === "followers") return followers;
+    if (activeModal === "following") return following;
+    return [];
+  }, [activeModal, followers, following]);
+
+  const modalState = useMemo(() => {
+    if (activeModal === "followers") {
+      return { hasMore: followersHasMore, isLoading: isLoadingFollowers };
+    }
+
+    if (activeModal === "following") {
+      return { hasMore: followingHasMore, isLoading: isLoadingFollowing };
+    }
+
+    return { hasMore: false, isLoading: false };
+  }, [activeModal, followersHasMore, followingHasMore, isLoadingFollowers, isLoadingFollowing]);
+
+  const handleCloseModal = () => {
+    if (activeModal === "followers") {
+      profileStore.resetFollowers();
+    }
+
+    if (activeModal === "following") {
+      profileStore.resetFollowing();
+    }
+
+    setActiveModal(null);
+  };
+
+  const handleLoadMore = () => {
+    if (!activeModal) return;
+
+    if (activeModal === "followers") {
+      const nextPage = Math.floor(followers.length / PAGE_SIZE) + 1;
+      void profileStore.fetchMyFollowers({ page: nextPage, limit: PAGE_SIZE });
+      return;
+    }
+
+    const nextPage = Math.floor(following.length / PAGE_SIZE) + 1;
+    void profileStore.fetchMyFollowing({ page: nextPage, limit: PAGE_SIZE });
+  };
+
+  return (
+    <>
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-1 items-start gap-5">
+            <div className="relative size-24 shrink-0 overflow-hidden rounded-3xl border border-white/15">
+              <Image
+                src={profileAvatar}
+                alt={`${userFullName} portrait`}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 96px, 150px"
+              />
             </div>
+            <div className="space-y-3">
+              <div>
+                <h1 className="text-4xl font-semibold tracking-tight">{userFullName}</h1>
+                <p className="mt-2 text-sm leading-6 text-white/70">{profile?.userBio}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-white/60">
+                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1">{genderLabel}</span>
+              </div>
+            </div>
+          </div>
+          <div className="grid w-full max-w-xs gap-4 rounded-2xl border border-white/10 bg-neutral-900/80 p-5 text-sm text-white/70">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-white/40">Membership</p>
+              <p className="mt-1 font-medium text-white">{profile?.role}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-white/40">Joined</p>
+              <p className="mt-1">{getMonthYear(profile?.createdAt)}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-white/40">Last updated</p>
+              <p className="mt-1">{getTimeAgo(profile?.updatedAt)}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-white/40">Connections</p>
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => setActiveModal("followers")}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left transition hover:bg-white/10"
+                >
+                  <p className="text-2xl font-semibold text-white">{followerCount}</p>
+                  <p className="text-xs uppercase tracking-wide text-white/50">Followers</p>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveModal("following")}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left transition hover:bg-white/10"
+                >
+                  <p className="text-2xl font-semibold text-white">{followingCount}</p>
+                  <p className="text-xs uppercase tracking-wide text-white/50">Following</p>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
-    );
+      </div>
+
+      <UserListModal
+        open={activeModal !== null}
+        title={activeModal === "followers" ? "Followers" : "Following"}
+        users={activeUsers}
+        isLoading={Boolean(activeModal) && modalState.isLoading}
+        hasMore={Boolean(activeModal) && modalState.hasMore}
+        onClose={handleCloseModal}
+        onLoadMore={handleLoadMore}
+      />
+    </>
+  );
 }

--- a/src/components/profile/UserListModal.tsx
+++ b/src/components/profile/UserListModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Image from "next/image";
+import { Button } from "@/components/ui/Button";
+import ModalShell from "./edit/overview/ModalShell";
+import { UserDTO } from "@/helpers/types";
+import { getUserAvatar, getUserFullName, getUsername } from "@/helpers/utils/user";
+
+type UserListModalProps = {
+  open: boolean;
+  title: string;
+  users: UserDTO[];
+  isLoading: boolean;
+  hasMore: boolean;
+  onClose: () => void;
+  onLoadMore: () => void;
+};
+
+export default function UserListModal({
+  open,
+  title,
+  users,
+  isLoading,
+  hasMore,
+  onClose,
+  onLoadMore,
+}: UserListModalProps) {
+  return (
+    <ModalShell open={open} onBackdrop={onClose}>
+      <div className="flex max-h-[70vh] flex-col">
+        <div className="flex items-center justify-between px-6 pb-4 pt-6 sm:px-8">
+          <h2 className="text-xl font-semibold sm:text-2xl">{title}</h2>
+          <Button
+            type="button"
+            onClick={onClose}
+            variant="frostedIconCompact"
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 pb-6 sm:px-8">
+          {isLoading && users.length === 0 ? (
+            <div className="py-8 text-center text-sm text-white/60">Loading...</div>
+          ) : null}
+
+          {!isLoading && users.length === 0 ? (
+            <div className="py-8 text-center text-sm text-white/60">No users yet</div>
+          ) : null}
+
+          <ul className="space-y-4">
+            {users.map((user) => {
+              const avatar = getUserAvatar(user);
+              const fullName = getUserFullName(user);
+              const username = getUsername(user);
+
+              return (
+                <li
+                  key={user._id}
+                  className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="relative size-12 overflow-hidden rounded-2xl border border-white/10">
+                      <Image
+                        src={avatar}
+                        alt={`${fullName} avatar`}
+                        fill
+                        className="object-cover"
+                        sizes="48px"
+                      />
+                    </div>
+                    <div>
+                      <p className="font-medium text-white">{fullName}</p>
+                      {username ? <p className="text-sm text-white/50">{username}</p> : null}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+
+          {isLoading && users.length > 0 ? (
+            <div className="py-4 text-center text-sm text-white/60">Loading...</div>
+          ) : null}
+        </div>
+
+        {hasMore ? (
+          <div className="border-t border-white/10 px-6 py-4 sm:px-8">
+            <Button
+              type="button"
+              onClick={onLoadMore}
+              variant="outline"
+              className="w-full"
+              disabled={isLoading}
+            >
+              {isLoading ? "Loading..." : "Load more"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </ModalShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add connection actions to the profile card that open follower and following lists
- create a reusable user list modal that renders people returned from the profile store
- fetch followers and following from the profile store with pagination when the modal opens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d466c64cd48333809d180ef39754f5