### PR TITLE
Add AI agent filters to My Profile timeline

### DIFF
--- a/src/app/profile/my/page.tsx
+++ b/src/app/profile/my/page.tsx
@@ -2,26 +2,23 @@
 
 import AppShell from "@/components/AppShell";
 import EditProfileDialog from "@/components/profile/edit/EditProfileDialog";
-
-
 import GradientBackdrop from "@/components/profile/GradientBackdrop";
 import HeaderActions from "@/components/profile/HeaderActions";
 import ProfileCard from "@/components/profile/ProfileCard";
 import BadgesRow from "@/components/profile/BadgesRow";
 import AiAgentsTimeline from "@/components/profile/AiAgentsTimeline";
 import Milestones from "@/components/profile/Milestones";
-import CommunityStats from "@/components/profile/CommunityStats";
 import MoreTalkies from "@/components/profile/MoreTalkies";
 
-
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 
 export default function MyProfilePage() {
   const { profileStore, uiStore, aiBotStore } = useRootStore();
   const profile = useStoreData(profileStore, (store) => store.myProfile);
   const aiAgents = useStoreData(aiBotStore, (store) => store.myBots);
+  const subscribedAiAgents = useStoreData(aiBotStore, (store) => store.subscribedBots);
 
   const badges = useStoreData(profileStore, (store) => store.badges);
   const talkies = useStoreData(profileStore, (store) => store.talkies);
@@ -29,10 +26,33 @@ export default function MyProfilePage() {
   const isDialogOpen = useStoreData(uiStore, (store) => store.isEditProfileDialogOpen);
   const moreTalkies = talkies.slice(3);
 
+  const [activeFilter, setActiveFilter] = useState<"my" | "subscribed">("my");
+
   useEffect(() => {
     void profileStore.fetchMyProfile();
     void aiBotStore.fetchMyAiBots();
-  }, [profileStore]);
+    void aiBotStore.fetchSubscribedAiBots();
+  }, [profileStore, aiBotStore]);
+
+  const filters = [
+    { value: "my" as const, label: "My AI Agents" },
+    { value: "subscribed" as const, label: "Subscribed AI Agents" },
+  ];
+
+  const timelineCopy =
+    activeFilter === "my"
+      ? {
+          title: "My AI Agents",
+          description: "Here are the AI agents you have created.",
+          empty: "You haven't created any AI agents yet.",
+        }
+      : {
+          title: "Subscribed AI Agents",
+          description: "AI agents you follow will appear here.",
+          empty: "You aren't subscribed to any AI agents yet.",
+        };
+
+  const filteredAiAgents = activeFilter === "my" ? aiAgents : subscribedAiAgents;
 
 
   return (
@@ -55,11 +75,40 @@ export default function MyProfilePage() {
 
           <section className="mt-12 grid gap-6 lg:grid-cols-[1fr_320px]">
             <div className="space-y-6">
-              <AiAgentsTimeline items={aiAgents} />
+              <AiAgentsTimeline
+                items={filteredAiAgents}
+                title={timelineCopy.title}
+                description={timelineCopy.description}
+                emptyMessage={timelineCopy.empty}
+              />
             </div>
 
             <aside className="space-y-6">
-              <CommunityStats />
+              <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <h2 className="text-lg font-semibold text-white">Filter AI Agents</h2>
+                <p className="mt-2 text-sm text-white/70">
+                  Choose whether to see your own creations or the agents you're subscribed to.
+                </p>
+                <div className="mt-4 grid gap-2">
+                  {filters.map((filter) => {
+                    const isActive = activeFilter === filter.value;
+                    return (
+                      <button
+                        key={filter.value}
+                        type="button"
+                        onClick={() => setActiveFilter(filter.value)}
+                        className={`w-full rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
+                          isActive
+                            ? "bg-white text-neutral-900 shadow-[0_0_0_1px_rgba(255,255,255,0.35)]"
+                            : "bg-white/5 text-white/70 hover:bg-white/10"
+                        }`}
+                      >
+                        {filter.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
             </aside>
           </section>
         </div>

--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -1,17 +1,29 @@
 import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
 import AiAgentCard from "./AiAgentCard";
 
+type AiAgentsTimelineProps = {
+  items: AiBotDTO[];
+  title: string;
+  description: string;
+  emptyMessage?: string;
+};
 
-export default function AiAgentsTimeline({ items }: { items: AiBotDTO[] }) {
-    return (
-        <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="text-lg font-semibold text-white">AI Agents list</h2>
-            <p className="mt-2 text-sm text-white/70">Here are the AI ​​agents you have created.</p>
-            <div className="mt-6 space-y-4">
-                {items.slice(0, 3).map((aiAgent) => (
-                    <AiAgentCard key={aiAgent.name} aiAgent={aiAgent} />
-                ))}
-            </div>
-        </section>
-    );
+export default function AiAgentsTimeline({ items, title, description, emptyMessage }: AiAgentsTimelineProps) {
+  const hasItems = items.length > 0;
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      <p className="mt-2 text-sm text-white/70">{description}</p>
+      <div className="mt-6 space-y-4">
+        {hasItems ? (
+          items.map((aiAgent) => <AiAgentCard key={aiAgent._id ?? aiAgent.name} aiAgent={aiAgent} />)
+        ) : (
+          <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
+            {emptyMessage ?? "No AI agents to display yet."}
+          </p>
+        )}
+      </div>
+    </section>
+  );
 }

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -181,6 +181,13 @@ export class ProfileService {
   }
 
   /**
+   * Получить список AI-ботов, на которых подписан текущий пользователь.
+   */
+  public async getSubscribedAiBots(): Promise<AxiosResponse<UserDTO[], any>> {
+    return $api.get(`/profile/ai-bots/subscribed`);
+  }
+
+  /**
    * Создать нового AI-бота. Для передачи аватара необходимо использовать FormData.
    */
   public async createAiBot(formData: FormData): Promise<AxiosResponse<UserDTO, any>> {

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -39,6 +39,7 @@ export class AiBotStore extends BaseStore {
   botPhotos: string[] = [];
 
   myBots: UserDTO[] = [];
+  subscribedBots: UserDTO[] = [];
   photosLoading = false;
   photosUpdating = false;
   isAiUserLoading = false;
@@ -225,6 +226,19 @@ export class AiBotStore extends BaseStore {
       const { data } = await this.profileService.getMyAiBots();
       runInAction(() => {
         this.myBots = data;
+        this.notify();
+      });
+    } catch (e) {
+      // uiStore.showSnackbar("Failed", "error");
+    }
+  }
+
+  async fetchSubscribedAiBots() {
+    try {
+      const { data } = await this.profileService.getSubscribedAiBots();
+      runInAction(() => {
+        this.subscribedBots = data;
+        this.notify();
       });
     } catch (e) {
       // uiStore.showSnackbar("Failed", "error");
@@ -236,6 +250,7 @@ export class AiBotStore extends BaseStore {
       const { data } = await this.profileService.createAiBot(formData);
       runInAction(() => {
         this.myBots.push(data);
+        this.notify();
       });
       // uiStore.showSnackbar("Created", "success");
       return data;
@@ -263,7 +278,10 @@ export class AiBotStore extends BaseStore {
       if (updated) {
         runInAction(() => {
           const idx = this.myBots.findIndex(b => b._id === id);
-          if (idx !== -1) this.myBots[idx] = updated!;
+          if (idx !== -1) {
+            this.myBots[idx] = updated!;
+            this.notify();
+          }
         });
         // uiStore.showSnackbar("Updated", "success");
       }
@@ -277,6 +295,7 @@ export class AiBotStore extends BaseStore {
       await this.profileService.deleteAiBot(id);
       runInAction(() => {
         this.myBots = this.myBots.filter(b => b._id !== id);
+        this.notify();
       });
       // uiStore.showSnackbar("Deleted", "success");
     } catch (e) {


### PR DESCRIPTION
## Summary
- replace the Community Stats widget on the profile page with filter pills for owned or subscribed AI agents
- load subscribed AI bots via the profile service and expose them through the AI bot store alongside the existing list
- allow the AI agent timeline to render dynamic copy and an empty state based on the active filter

## Testing
- npm run lint *(fails: pre-existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d469e00e188333bcbf125f55f2ce65