### PR TITLE
feat(profile): enable profile editing with photo management

### DIFF
--- a/src/components/profile/edit/EditProfileDialog.tsx
+++ b/src/components/profile/edit/EditProfileDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { FormEventHandler, useEffect, useMemo, useState } from "react";
 
 import ModalShell from "./overview/ModalShell";
 import DialogHeader from "./overview/DialogHeader";
@@ -14,25 +14,57 @@ import FormActions from "./overview/FormActions";
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
 import { MyProfileDTO } from "@/helpers/types";
 import LastNameField from "./overview/LastNameField";
-
+import { getUserAvatar } from "@/helpers/utils/user";
+import { UpdateProfileProps } from "@/helpers/types/profile";
 
 type Props = {
   open: boolean;
   profile: MyProfileDTO;
   onClose: () => void;
-  onSave: (profile: MyProfileDTO) => void;
+  onSave?: (profile: MyProfileDTO) => void;
 };
 
 export default function EditProfileDialog({ open, profile, onClose, onSave }: Props) {
-  const [formState, setFormState] = useState<MyProfileDTO>(profile);
   const { profileStore } = useRootStore();
   const genderOptions = useStoreData(profileStore, (store) => store.genderOptions);
   const relationshipOptions = useStoreData(profileStore, (store) => store.relationshipOptions);
 
+  const [formState, setFormState] = useState<MyProfileDTO>(profile);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [shouldRemoveAvatar, setShouldRemoveAvatar] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [tempUrl, setTempUrl] = useState<string | null>(null);
+
+  const hasInitialAvatar = useMemo(() => Boolean(profile?.avatarFile), [profile?.avatarFile]);
+
   // sync incoming profile on open
   useEffect(() => {
-    if (open) setFormState(profile);
+    if (!open) return;
+
+    setFormState({ ...profile });
+    setAvatarFile(null);
+    setShouldRemoveAvatar(false);
+
+    const avatar = profile?.avatarFile ? getUserAvatar(profile) : null;
+    setAvatarPreview(avatar);
+
+    setTempUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return null;
+    });
   }, [open, profile]);
+
+  // cleanup created preview URL
+  useEffect(() => {
+    return () => {
+      if (tempUrl) {
+        URL.revokeObjectURL(tempUrl);
+      }
+    };
+  }, [tempUrl]);
 
   // ESC to close
   useEffect(() => {
@@ -44,11 +76,85 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, onClose]);
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    onSave(formState);
-    onClose();
+  const handleAvatarSelect = (file: File) => {
+    if (tempUrl) {
+      URL.revokeObjectURL(tempUrl);
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setAvatarFile(file);
+    setAvatarPreview(objectUrl);
+    setShouldRemoveAvatar(false);
+    setTempUrl(objectUrl);
   };
+
+  const handleAvatarRemove = () => {
+    if (tempUrl) {
+      URL.revokeObjectURL(tempUrl);
+      setTempUrl(null);
+    }
+
+    if (avatarFile) {
+      const avatar = profile?.avatarFile ? getUserAvatar(profile) : null;
+      setAvatarPreview(avatar);
+      setAvatarFile(null);
+      setShouldRemoveAvatar(false);
+      return;
+    }
+
+    setAvatarFile(null);
+    setAvatarPreview(null);
+    setShouldRemoveAvatar(Boolean(profile?.avatarFile));
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+
+    const payload: UpdateProfileProps = {
+      name: formState.name?.trim() || undefined,
+      lastname: formState.lastname?.trim() || undefined,
+      username: formState.username?.trim() || undefined,
+      userBio: formState.userBio || undefined,
+      gender: formState.gender ? (formState.gender as UpdateProfileProps["gender"]) : undefined,
+      profession: formState.profession || undefined,
+      phone: formState.phone || undefined,
+    };
+
+    const filteredPayload = Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined && value !== "")
+    ) as UpdateProfileProps;
+
+    setIsSubmitting(true);
+    try {
+      if (Object.keys(filteredPayload).length > 0) {
+        await profileStore.updateProfile(filteredPayload);
+      }
+
+      if (avatarFile) {
+        const formData = new FormData();
+        formData.append("avatar", avatarFile);
+        await profileStore.uploadProfilePhoto(formData);
+      } else if (shouldRemoveAvatar && profile?.avatarFile) {
+        await profileStore.deleteProfilePhoto(profile.avatarFile);
+      }
+
+      await profileStore.fetchMyProfile();
+      onSave?.(profileStore.myProfile);
+      onClose();
+    } catch (error) {
+      console.error("Failed to update profile", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const relationshipChoices = useMemo(() => {
+    const baseOptions = [...relationshipOptions];
+    if (formState.profession && !baseOptions.includes(formState.profession)) {
+      baseOptions.push(formState.profession);
+    }
+    return baseOptions;
+  }, [relationshipOptions, formState.profession]);
 
   return (
     <ModalShell open={open} onBackdrop={onClose}>
@@ -56,37 +162,43 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
         <DialogHeader onClose={onClose} />
 
         <div className="space-y-6 px-6 pb-6 sm:px-8 sm:pb-8">
-          <HeroRow userName={formState.username || 'userName'} />
+          <HeroRow
+            userName={formState.name || formState.username || "user"}
+            avatarUrl={avatarPreview}
+            onAvatarSelect={handleAvatarSelect}
+            onAvatarRemove={handleAvatarRemove}
+            canRemoveAvatar={Boolean(avatarPreview) || Boolean(avatarFile) || (hasInitialAvatar && !shouldRemoveAvatar)}
+          />
 
           <NameField
-            value={formState.name}
-            onChange={(val) => setFormState((s) => ({ ...s, userName: val }))}
+            value={formState.name || ""}
+            onChange={(val) => setFormState((s) => ({ ...s, name: val }))}
           />
 
           <LastNameField
-            value={formState.lastname}
-            onChange={(val) => setFormState((s) => ({ ...s, userName: val }))}
+            value={formState.lastname || ""}
+            onChange={(val) => setFormState((s) => ({ ...s, lastname: val }))}
           />
 
           <GenderGroup
-            value={'male'}
+            value={formState.gender || ""}
             onChange={(val) => setFormState((s) => ({ ...s, gender: val }))}
             options={genderOptions}
           />
 
           <IntroField
             value={formState.userBio}
-            onChange={(val) => setFormState((s) => ({ ...s, intro: val }))}
+            onChange={(val) => setFormState((s) => ({ ...s, userBio: val }))}
           />
 
           <RelationshipField
-            value={'test'}
-            onChange={(val) => setFormState((s) => ({ ...s, relationshipPreference: val }))}
-            options={relationshipOptions}
+            value={formState.profession || relationshipChoices[0] || ""}
+            onChange={(val) => setFormState((s) => ({ ...s, profession: val }))}
+            options={relationshipChoices}
           />
 
           <Notice />
-          <FormActions onCancel={onClose} />
+          <FormActions onCancel={onClose} isSubmitting={isSubmitting} />
         </div>
       </form>
     </ModalShell>

--- a/src/components/profile/edit/overview/FormActions.tsx
+++ b/src/components/profile/edit/overview/FormActions.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/components/ui/Button";
 
 export default function FormActions({
   onCancel,
+  isSubmitting = false,
 }: {
   onCancel: () => void;
+  isSubmitting?: boolean;
 }) {
   return (
     <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
@@ -13,14 +15,16 @@ export default function FormActions({
         type="button"
         onClick={onCancel}
         variant="outlineWide"
+        disabled={isSubmitting}
       >
         Cancel
       </Button>
       <Button
         type="submit"
         variant="solidWhiteWide"
+        disabled={isSubmitting}
       >
-        Save
+        {isSubmitting ? "Saving..." : "Save"}
       </Button>
     </div>
   );

--- a/src/components/profile/edit/overview/HeroRow.tsx
+++ b/src/components/profile/edit/overview/HeroRow.tsx
@@ -1,12 +1,80 @@
 "use client";
 
-export default function HeroRow({ userName }: { userName?: string }) {
+import Image from "next/image";
+import { ChangeEvent, useRef } from "react";
+
+type Props = {
+  userName?: string;
+  avatarUrl?: string | null;
+  onAvatarSelect?: (file: File) => void;
+  onAvatarRemove?: () => void;
+  canRemoveAvatar?: boolean;
+};
+
+export default function HeroRow({ userName, avatarUrl, onAvatarSelect, onAvatarRemove, canRemoveAvatar }: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file && onAvatarSelect) {
+      onAvatarSelect(file);
+    }
+
+    // allow selecting the same file again
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  };
+
   return (
-    <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center">
-      <div className="grid size-16 shrink-0 place-items-center rounded-2xl bg-gradient-to-br from-orange-400 to-red-500 text-2xl font-semibold">
-        {(userName || "?").charAt(0)}
+    <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="relative">
+          <div className="relative flex size-20 items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-orange-400 to-red-500 text-2xl font-semibold">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt="Profile avatar preview"
+                fill
+                className="object-cover"
+                sizes="80px"
+              />
+            ) : (
+              (userName || "?").charAt(0)
+            )}
+          </div>
+
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          <div className="mt-2 grid gap-2 sm:grid-cols-1">
+            <button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              className="w-full rounded-2xl border border-white/15 bg-white/5 px-4 py-2 text-xs font-medium uppercase tracking-wide text-white/80 transition hover:bg-white/10"
+            >
+              Change photo
+            </button>
+
+            {onAvatarRemove && canRemoveAvatar && (
+              <button
+                type="button"
+                onClick={onAvatarRemove}
+                className="w-full rounded-2xl border border-transparent bg-white/0 px-4 py-2 text-xs font-medium uppercase tracking-wide text-white/60 transition hover:text-white"
+              >
+                Remove photo
+              </button>
+            )}
+          </div>
+        </div>
       </div>
-      <p className="text-center text-sm text-neutral-300 sm:text-left">
+
+      <p className="text-center text-sm text-neutral-300 sm:mt-2 sm:text-left">
         Update your personal details to help others know you better.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- wire EditProfileDialog up to ProfileStore by saving text fields through updateProfile and refreshing store data
- add avatar upload/remove controls that call uploadProfilePhoto and deleteProfilePhoto with live preview handling
- improve dialog UX with proper field bindings and submission loading state on form actions

## Testing
- npx eslint src/components/profile/edit/EditProfileDialog.tsx src/components/profile/edit/overview/HeroRow.tsx src/components/profile/edit/overview/FormActions.tsx
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f2aa30f483339f6a7e4f9d811ca7