### PR TITLE
Align profile updates with backend constraints

### DIFF
--- a/src/app/profile/my/page.tsx
+++ b/src/app/profile/my/page.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 export default function MyProfilePage() {
   const { profileStore, uiStore, aiBotStore } = useRootStore();
   const profile = useStoreData(profileStore, (store) => store.myProfile);
+  const genderLabels = useStoreData(profileStore, (store) => store.genderLabels);
   const aiAgents = useStoreData(aiBotStore, (store) => store.myBots);
   const subscribedAiAgents = useStoreData(aiBotStore, (store) => store.subscribedBots);
 
@@ -37,12 +38,12 @@ export default function MyProfilePage() {
       ? {
           title: "My AI Agents",
           description: "Here are the AI agents you have created.",
-          empty: "You haven't created any AI agents yet.",
+          empty: "You haven’t created any AI agents yet.",
         }
       : {
           title: "Subscribed AI Agents",
           description: "AI agents you follow will appear here.",
-          empty: "You aren't subscribed to any AI agents yet.",
+          empty: "You aren’t subscribed to any AI agents yet.",
         };
 
   const filteredAiAgents = activeFilter === "my" ? aiAgents : subscribedAiAgents;
@@ -63,7 +64,10 @@ export default function MyProfilePage() {
         <div className="mx-auto w-full max-w-5xl px-4 pb-20 pt-14">
           <header className="space-y-8">
             <HeaderActions onEdit={() => uiStore.openEditProfileDialog()} />
-            <ProfileCard profile={profile} genderLabel={'Male'} />
+            <ProfileCard
+              profile={profile}
+              genderLabel={profile?.gender ? genderLabels[profile.gender] ?? profile.gender : "Not specified"}
+            />
           </header>
 
           <section className="mt-12 grid gap-6 lg:grid-cols-[1fr_320px]">
@@ -80,7 +84,7 @@ export default function MyProfilePage() {
               <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
                 <h2 className="text-lg font-semibold text-white">Filter AI Agents</h2>
                 <p className="mt-2 text-sm text-white/70">
-                  Choose whether to see your own creations or the agents you're subscribed to.
+                  Choose whether to see your own creations or the agents you’re subscribed to.
                 </p>
                 <div className="mt-4 grid gap-3">
                   {filters.map((filter) => {

--- a/src/components/profile/edit/EditProfileDialog.tsx
+++ b/src/components/profile/edit/EditProfileDialog.tsx
@@ -121,7 +121,14 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
     };
 
     const filteredPayload = Object.fromEntries(
-      Object.entries(payload).filter(([, value]) => value !== undefined && value !== "")
+      Object.entries(payload).filter(([key, value]) => {
+        if (value === undefined || value === "") {
+          return false;
+        }
+
+        const originalValue = profile?.[key as keyof MyProfileDTO];
+        return value !== originalValue;
+      })
     ) as UpdateProfileProps;
 
     setIsSubmitting(true);
@@ -132,7 +139,7 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
 
       if (avatarFile) {
         const formData = new FormData();
-        formData.append("avatar", avatarFile);
+        formData.append("file", avatarFile);
         await profileStore.uploadProfilePhoto(formData);
       } else if (shouldRemoveAvatar && profile?.avatarFile) {
         await profileStore.deleteProfilePhoto(profile.avatarFile);

--- a/src/helpers/data/profile.ts
+++ b/src/helpers/data/profile.ts
@@ -2,9 +2,8 @@ import { Clock3, Flame, Heart } from "lucide-react";
 import type { TalkieCard } from "@/helpers/types/profile";
 
 export const genderOptions = [
-  { value: "he_him", label: "He/Him" },
-  { value: "she_her", label: "She/Her" },
-  { value: "they_them", label: "They/Them" },
+  { value: "MALE", label: "Male" },
+  { value: "FEMALE", label: "Female" },
 ] as const;
 
 export const relationshipOptions = [
@@ -94,14 +93,13 @@ export const milestones = [
 
 export const initialProfile = {
     userName: "Vadim Stepanov",
-    gender: "he_him",
+    gender: "MALE",
     intro: "AI product designer exploring the edges of digital companions.",
     relationshipPreference: "View your relationship preference",
 };
 
 
 export const genderLabels: Record<string, string> = {
-    he_him: "He/Him",
-    she_her: "She/Her",
-    they_them: "They/Them",
+    MALE: "Male",
+    FEMALE: "Female",
 };


### PR DESCRIPTION
## Summary
- update profile gender options to send MALE/FEMALE values expected by the backend
- only send changed profile fields and post avatar files using the expected "file" form-data key
- surface the correct gender label on the profile card and clean apostrophe usage in copy

## Testing
- `npm run lint` *(fails: pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f8571aac833380cb81a63e4580e6