### PR TITLE
Fix static export for user profile page

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import AppShell from "@/components/AppShell";
+import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
+
+import GradientBackdrop from "@/components/user/GradientBackdrop";
+import HeaderBar from "@/components/user/HeaderBar";
+import UserHero from "@/components/user/UserHero";
+import SectionHeader from "@/components/user/SectionHeader";
+import TalkieGrid from "@/components/user/TalkieGrid";
+
+import { useRootStore, useStoreData } from "@/stores/StoreProvider";
+import { getUserAvatar, getUserFullName } from "@/helpers/utils/user";
+
+interface UserProfilePageProps {
+  profileId?: string;
+}
+
+export default function UserProfilePage({ profileId }: UserProfilePageProps) {
+  const { routes } = useAuthRoutes();
+  const { profileStore } = useRootStore();
+
+  const profile = useStoreData(profileStore, (store) => store.profile);
+  const templateProfile = useStoreData(profileStore, (store) => store.getProfileInitial);
+  const isLoadingProfile = useStoreData(profileStore, (store) => store.isLoadingProfile);
+
+  useEffect(() => {
+    if (!profileId) return;
+
+    void profileStore.fetchProfileById(profileId);
+
+    return () => {
+      profileStore.clearViewedProfile();
+    };
+  }, [profileId, profileStore]);
+
+  const heroData = useMemo(() => {
+    const hasProfile = Boolean(profile?._id);
+    const source = hasProfile ? profile : undefined;
+
+    return {
+      name: hasProfile ? getUserFullName(profile) : templateProfile.name,
+      intro: source?.userBio ?? templateProfile.intro,
+      location: source?.city?.name ?? templateProfile.location,
+      avatar: hasProfile ? getUserAvatar(profile) : templateProfile.avatar,
+      badges: templateProfile.badges,
+    };
+  }, [profile, templateProfile]);
+
+  return (
+    <AppShell>
+      <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
+        <GradientBackdrop />
+
+        <div className="mx-auto w-full max-w-5xl px-4 pb-20 pt-14">
+          <header className="space-y-8">
+            <HeaderBar />
+            <UserHero
+              name={heroData.name}
+              intro={heroData.intro}
+              location={heroData.location}
+              avatar={heroData.avatar}
+              badges={heroData.badges}
+              messageHref={routes.adminChat}
+            />
+          </header>
+
+          <section className="mt-12 space-y-6">
+            <SectionHeader
+              title="Talkie List"
+              subtitle={"Where the stories stay safe and the signal stays clear."}
+              actionLabel="View archive"
+            />
+            <TalkieGrid items={templateProfile.talkies} />
+            {isLoadingProfile && <p className="text-sm text-white/60">Loading profile…</p>}
+          </section>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/profile/user/[id]/page.tsx
+++ b/src/app/profile/user/[id]/page.tsx
@@ -1,83 +1,17 @@
-"use client";
+import ClientUserProfilePage from "./ClientUserProfilePage";
 
-import { useEffect, useMemo } from "react";
-import { useParams } from "next/navigation";
+type PageParams = {
+  params: {
+    id: string | string[];
+  };
+};
 
-import AppShell from "@/components/AppShell";
-import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
+export default function Page({ params }: PageParams) {
+  const profileId = Array.isArray(params.id) ? params.id[0] : params.id;
 
-import GradientBackdrop from "@/components/user/GradientBackdrop";
-import HeaderBar from "@/components/user/HeaderBar";
-import UserHero from "@/components/user/UserHero";
-import SectionHeader from "@/components/user/SectionHeader";
-import TalkieGrid from "@/components/user/TalkieGrid";
+  return <ClientUserProfilePage profileId={profileId} />;
+}
 
-import { useRootStore, useStoreData } from "@/stores/StoreProvider";
-import { getUserAvatar, getUserFullName } from "@/helpers/utils/user";
-
-export default function UserProfilePage() {
-  const params = useParams<{ id: string }>();
-  const { routes } = useAuthRoutes();
-  const { profileStore } = useRootStore();
-
-  const profile = useStoreData(profileStore, (store) => store.profile);
-  const templateProfile = useStoreData(profileStore, (store) => store.getProfileInitial);
-  const isLoadingProfile = useStoreData(profileStore, (store) => store.isLoadingProfile);
-
-  const profileId = Array.isArray(params?.id) ? params.id[0] : params?.id;
-
-  useEffect(() => {
-    if (!profileId) return;
-
-    void profileStore.fetchProfileById(profileId);
-
-    return () => {
-      profileStore.clearViewedProfile();
-    };
-  }, [profileId, profileStore]);
-
-  const heroData = useMemo(() => {
-    const hasProfile = Boolean(profile?._id);
-    const source = hasProfile ? profile : undefined;
-
-    return {
-      name: hasProfile ? getUserFullName(profile) : templateProfile.name,
-      intro: source?.userBio ?? templateProfile.intro,
-      location: source?.city?.name ?? templateProfile.location,
-      avatar: hasProfile ? getUserAvatar(profile) : templateProfile.avatar,
-      badges: templateProfile.badges,
-    };
-  }, [profile, templateProfile]);
-
-  return (
-    <AppShell>
-      <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
-        <GradientBackdrop />
-
-        <div className="mx-auto w-full max-w-5xl px-4 pb-20 pt-14">
-          <header className="space-y-8">
-            <HeaderBar />
-            <UserHero
-              name={heroData.name}
-              intro={heroData.intro}
-              location={heroData.location}
-              avatar={heroData.avatar}
-              badges={heroData.badges}
-              messageHref={routes.adminChat}
-            />
-          </header>
-
-          <section className="mt-12 space-y-6">
-            <SectionHeader
-              title="Talkie List"
-              subtitle={"Where the stories stay safe and the signal stays clear."}
-              actionLabel="View archive"
-            />
-            <TalkieGrid items={templateProfile.talkies} />
-            {isLoadingProfile && <p className="text-sm text-white/60">Loading profile…</p>}
-          </section>
-        </div>
-      </div>
-    </AppShell>
-  );
+export function generateStaticParams() {
+  return [];
 }


### PR DESCRIPTION
## Summary
- move the user profile page client logic into a dedicated client component
- add a server entry point that passes the route param and defines generateStaticParams for static export builds

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fac7d89883338782f022af22dac6