### PR TITLE
Add follow toggle to profile header

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import AppShell from "@/components/AppShell";
 import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
@@ -25,6 +25,10 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
   const profile = useStoreData(profileStore, (store) => store.profile);
   const templateProfile = useStoreData(profileStore, (store) => store.getProfileInitial);
   const isLoadingProfile = useStoreData(profileStore, (store) => store.isLoadingProfile);
+  const isFollowing = profile?.isFollowing;
+  const profileUserId = profile?._id;
+
+  const [isUpdatingFollow, setIsUpdatingFollow] = useState(false);
 
   useEffect(() => {
     if (!profileId) return;
@@ -49,6 +53,18 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
     };
   }, [profile, templateProfile]);
 
+  const handleToggleFollow = useCallback(async () => {
+    if (!profileUserId) return;
+
+    setIsUpdatingFollow(true);
+
+    try {
+      await profileStore.followProfile(profileUserId);
+    } finally {
+      setIsUpdatingFollow(false);
+    }
+  }, [profileStore, profileUserId]);
+
   return (
     <AppShell>
       <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
@@ -56,7 +72,12 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
 
         <div className="mx-auto w-full max-w-5xl px-4 pb-20 pt-14">
           <header className="space-y-8">
-            <HeaderBar />
+            <HeaderBar
+              isFollowing={isFollowing}
+              isBusy={isUpdatingFollow}
+              onToggleFollow={handleToggleFollow}
+              disableFollowAction={!profileUserId}
+            />
             <UserHero
               name={heroData.name}
               intro={heroData.intro}

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -1,25 +1,51 @@
-import { ArrowLeft, MoreHorizontal, Share2, Sparkles } from "lucide-react";
-import { Button } from '@/components/ui/Button';
+import { ArrowLeft, Check, MoreHorizontal, Share2, Sparkles } from "lucide-react";
 
+import { Button } from "@/components/ui/Button";
 
-export default function HeaderBar() {
-    return (
-        <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-                <Button variant="frostedIcon">
-                    <ArrowLeft className="size-5" />
-                </Button>
-                <Button variant="frostedIcon">
-                    <Share2 className="size-5" />
-                </Button>
-                <Button variant="frostedIcon">
-                    <MoreHorizontal className="size-5" />
-                </Button>
-            </div>
-            <Button variant="frostedPill">
-                <Sparkles className="size-4" />
-                Subscribed
-            </Button>
-        </div>
-    );
+interface HeaderBarProps {
+  isFollowing?: boolean;
+  isBusy?: boolean;
+  disableFollowAction?: boolean;
+  onToggleFollow?: () => void;
+}
+
+export default function HeaderBar({
+  isFollowing,
+  isBusy,
+  disableFollowAction,
+  onToggleFollow,
+}: HeaderBarProps) {
+  const isActionDisabled = disableFollowAction || isBusy || !onToggleFollow;
+  const buttonLabel = isBusy
+    ? "Processing..."
+    : isFollowing
+      ? "Subscribed"
+      : "Subscribe";
+  const ButtonIcon = isFollowing ? Check : Sparkles;
+  const buttonVariant = isFollowing ? "frostedPill" : "subscribe";
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex items-center gap-2">
+        <Button variant="frostedIcon">
+          <ArrowLeft className="size-5" />
+        </Button>
+        <Button variant="frostedIcon">
+          <Share2 className="size-5" />
+        </Button>
+        <Button variant="frostedIcon">
+          <MoreHorizontal className="size-5" />
+        </Button>
+      </div>
+      <Button
+        variant={buttonVariant}
+        onClick={onToggleFollow}
+        disabled={isActionDisabled}
+        aria-pressed={Boolean(isFollowing)}
+      >
+        <ButtonIcon className="size-4" />
+        {buttonLabel}
+      </Button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- expose follow state in the user profile page and trigger follow/unfollow via the store
- update the header bar to reflect follow status and disable actions while processing

## Testing
- npm run lint *(fails: pre-existing lint violations around any types and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68d50f3e4bb08333a356acffe8b5ba20