### PR TITLE
refactor: reuse profile card across profile pages

### DIFF
--- a/src/app/profile/my/page.tsx
+++ b/src/app/profile/my/page.tsx
@@ -67,6 +67,7 @@ export default function MyProfilePage() {
             <ProfileCard
               profile={profile}
               genderLabel={profile?.gender ? genderLabels[profile.gender] ?? profile.gender : "Not specified"}
+              isCurrentUser
             />
           </header>
 

--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -1,29 +1,28 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import AppShell from "@/components/AppShell";
-import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
 
 import GradientBackdrop from "@/components/user/GradientBackdrop";
 import HeaderBar from "@/components/user/HeaderBar";
-import UserHero from "@/components/user/UserHero";
 import SectionHeader from "@/components/user/SectionHeader";
 import TalkieGrid from "@/components/user/TalkieGrid";
+import ProfileCard from "@/components/profile/ProfileCard";
 
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
-import { getUserAvatar, getUserFullName } from "@/helpers/utils/user";
 
 interface UserProfilePageProps {
   profileId?: string;
 }
 
 export default function UserProfilePage({ profileId }: UserProfilePageProps) {
-  const { routes } = useAuthRoutes();
   const { profileStore } = useRootStore();
 
   const profile = useStoreData(profileStore, (store) => store.profile);
   const templateProfile = useStoreData(profileStore, (store) => store.getProfileInitial);
+  const genderLabels = useStoreData(profileStore, (store) => store.genderLabels);
+  const myProfile = useStoreData(profileStore, (store) => store.myProfile);
   const isLoadingProfile = useStoreData(profileStore, (store) => store.isLoadingProfile);
   const isFollowing = profile?.isFollowing;
   const profileUserId = profile?._id;
@@ -40,19 +39,6 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
     };
   }, [profileId, profileStore]);
 
-  const heroData = useMemo(() => {
-    const hasProfile = Boolean(profile?._id);
-    const source = hasProfile ? profile : undefined;
-
-    return {
-      name: hasProfile ? getUserFullName(profile) : templateProfile.name,
-      intro: source?.userBio ?? templateProfile.intro,
-      location: source?.city?.name ?? templateProfile.location,
-      avatar: hasProfile ? getUserAvatar(profile) : templateProfile.avatar,
-      badges: templateProfile.badges,
-    };
-  }, [profile, templateProfile]);
-
   const handleToggleFollow = useCallback(async () => {
     if (!profileUserId) return;
 
@@ -64,6 +50,11 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
       setIsUpdatingFollow(false);
     }
   }, [profileStore, profileUserId]);
+
+  const genderLabel = profile?.gender
+    ? genderLabels[profile.gender] ?? profile.gender
+    : "Not specified";
+  const isViewingOwnProfile = Boolean(profileUserId && myProfile?._id === profileUserId);
 
   return (
     <AppShell>
@@ -78,13 +69,10 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               onToggleFollow={handleToggleFollow}
               disableFollowAction={!profileUserId}
             />
-            <UserHero
-              name={heroData.name}
-              intro={heroData.intro}
-              location={heroData.location}
-              avatar={heroData.avatar}
-              badges={heroData.badges}
-              messageHref={routes.adminChat}
+            <ProfileCard
+              profile={profile}
+              genderLabel={genderLabel}
+              isCurrentUser={isViewingOwnProfile}
             />
           </header>
 


### PR DESCRIPTION
## Summary
- generalize ProfileCard component so it can render both the current user and other users
- reuse ProfileCard on the public user profile page and compute gender labels there
- ensure follower/following modals load data for the appropriate profile owner

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d511aab76083339dfaa2bbc6fdddce