### PR TITLE
Fetch user-created AI bots on profile page

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import AppShell from "@/components/AppShell";
 
@@ -26,7 +26,7 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
   const isFollowing = profile?.isFollowing;
   const profileUserId = profile?._id;
 
-  const selectedAiBot = useStoreData(aiBotStore, (store) => store.selectAiBot);
+  const userAiBots = useStoreData(aiBotStore, (store) => store.userAiBots);
   const isLoadingAiBot = useStoreData(aiBotStore, (store) => store.isAiUserLoading);
 
   const [isUpdatingFollow, setIsUpdatingFollow] = useState(false);
@@ -35,11 +35,12 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
     if (!profileId) return;
 
     void profileStore.fetchProfileById(profileId);
-    void aiBotStore.fetchAiBotById(profileId);
+    void aiBotStore.fetchAiBotsByUserId(profileId);
 
     return () => {
       profileStore.clearViewedProfile();
       aiBotStore.clearSelectedAiBot();
+      aiBotStore.clearUserAiBots();
     };
   }, [profileId, profileStore, aiBotStore]);
 
@@ -59,8 +60,6 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
     ? genderLabels[profile.gender] ?? profile.gender
     : "Not specified";
   const isViewingOwnProfile = Boolean(profileUserId && myProfile?._id === profileUserId);
-
-  const aiBots = useMemo(() => (selectedAiBot ? [selectedAiBot] : []), [selectedAiBot]);
 
   return (
     <AppShell>
@@ -88,7 +87,7 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               subtitle={"Персональные напарники, созданные этим пользователем."}
               actionLabel="View archive"
             />
-            <AiBotGrid items={aiBots} isLoading={isLoadingAiBot} />
+            <AiBotGrid items={userAiBots} isLoading={isLoadingAiBot} />
             {(isLoadingProfile || isLoadingAiBot) && (
               <p className="text-sm text-white/60">Loading profile…</p>
             )}

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -172,6 +172,10 @@ export class ProfileService {
     return $api.get(`/profile/ai-bots/${botId}`);
   }
 
+  public async getAiBotsByCreator(creatorId: string): Promise<AxiosResponse<AiBotDTO[], any>> {
+    return $api.get(`/profile/ai-bots/created-by/${creatorId}`);
+  }
+
 
   /**
    * Получить список созданных AI-ботов текущего пользователя.

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -36,6 +36,7 @@ export class AiBotStore extends BaseStore {
   private profileService = ProfileService;
 
   selectAiBot: AiBotDTO | null = null;
+  userAiBots: AiBotDTO[] = [];
   botPhotos: string[] = [];
 
   myBots: UserDTO[] = [];
@@ -229,8 +230,36 @@ export class AiBotStore extends BaseStore {
     }
   }
 
+  async fetchAiBotsByUserId(userId: string) {
+    this.isAiUserLoading = true;
+    this.notify();
+    try {
+      const { data } = await this.profileService.getAiBotsByCreator(userId);
+      runInAction(() => {
+        this.userAiBots = data;
+      });
+      this.notify();
+      return data;
+    } catch (e) {
+      runInAction(() => {
+        this.userAiBots = [];
+      });
+      this.notify();
+    } finally {
+      runInAction(() => {
+        this.isAiUserLoading = false;
+      });
+      this.notify();
+    }
+  }
+
   clearSelectedAiBot() {
     this.selectAiBot = null;
+    this.notify();
+  }
+
+  clearUserAiBots() {
+    this.userAiBots = [];
     this.notify();
   }
 


### PR DESCRIPTION
## Summary
- load AI companions created by the viewed user on the profile page using the new backend endpoint
- store fetched bots in AiBotStore with lifecycle cleanup helpers
- expose a ProfileService client for the created-by endpoint

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d52015201883338cb42bcea38db7b9