### PR TITLE
Add AI bot links to profile views

### DIFF
--- a/src/components/profile/AiAgentCard.tsx
+++ b/src/components/profile/AiAgentCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import Image from "next/image";
 import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
 import { getUserAvatar } from "@/helpers/utils/user";
@@ -7,6 +8,7 @@ import { Clock3, Flame, Heart } from "lucide-react";
 export default function AiAgentCard({ aiAgent }: { aiAgent: AiBotDTO }) {
 
     const userAvatar = getUserAvatar(aiAgent);
+    const aiAgentHref = `/profile/ai-agent/${encodeURIComponent(aiAgent._id)}`;
 
     const stats = [
             { label: "episodes", value: "02", icon: Clock3 },
@@ -15,9 +17,13 @@ export default function AiAgentCard({ aiAgent }: { aiAgent: AiBotDTO }) {
         ]
 
     return (
-        <article className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-900/80 p-4 sm:flex-row">
+        <Link
+            href={aiAgentHref}
+            className="group flex flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-900/80 p-4 transition hover:border-violet-400/50 focus-visible:border-violet-400/70 focus-visible:outline-none sm:flex-row"
+            aria-label={`Открыть профиль AI-бота ${aiAgent.name}`}
+        >
             <div className="relative h-40 w-full shrink-0 overflow-hidden rounded-2xl sm:h-32 sm:w-32">
-                <Image src={userAvatar} alt={aiAgent.name} fill className="object-cover" sizes="(max-width: 640px) 100vw, 128px" />
+                <Image src={userAvatar} alt={aiAgent.name} fill className="object-cover transition duration-500 group-hover:scale-105 group-focus-visible:scale-105" sizes="(max-width: 640px) 100vw, 128px" />
             </div>
             <div className="flex flex-1 flex-col justify-between">
                 <div>
@@ -33,6 +39,6 @@ export default function AiAgentCard({ aiAgent }: { aiAgent: AiBotDTO }) {
                     ))}
                 </div>
             </div>
-        </article>
+        </Link>
     );
 }

--- a/src/components/user/AiBotCard.tsx
+++ b/src/components/user/AiBotCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import Image from "next/image";
 import { Users, UserPlus, Sparkles } from "lucide-react";
 
@@ -20,6 +21,7 @@ export default function AiBotCard({ bot }: AiBotCardProps) {
 
     const avatar = getUserAvatar(bot);
     const description = bot.userBio?.trim() || "Описание пока отсутствует.";
+    const botHref = `/profile/ai-agent/${encodeURIComponent(bot._id)}`;
 
     const stats = [
         { label: "Подписчики", value: formatNumber(bot.followers), icon: Users },
@@ -28,20 +30,21 @@ export default function AiBotCard({ bot }: AiBotCardProps) {
     ];
 
     return (
-        <article
-            tabIndex={0}
-            className="group flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-neutral-900/60 shadow-[0_20px_40px_-20px_rgba(59,0,104,0.45)] transition hover:border-violet-400/40 focus-visible:border-violet-400/60"
+        <Link
+            href={botHref}
+            className="group flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-neutral-900/60 shadow-[0_20px_40px_-20px_rgba(59,0,104,0.45)] transition hover:border-violet-400/40 focus-visible:border-violet-400/60 focus-visible:outline-none"
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
             onFocus={() => setIsHovered(true)}
             onBlur={() => setIsHovered(false)}
+            aria-label={`Открыть профиль AI-бота ${bot.name}`}
         >
             <div className="relative h-52 w-full overflow-hidden">
                 <Image
                     src={avatar}
                     alt={bot.name}
                     fill
-                    className="object-cover transition duration-500 group-hover:scale-105 group-focus-within:scale-105"
+                    className="object-cover transition duration-500 group-hover:scale-105 group-focus-visible:scale-105"
                     sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
                 />
                 <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/80 to-transparent" />
@@ -80,6 +83,6 @@ export default function AiBotCard({ bot }: AiBotCardProps) {
                     ))}
                 </div>
             </div>
-        </article>
+        </Link>
     );
 }


### PR DESCRIPTION
## Summary
- wrap AI agent cards on the "My profile" page with Next.js links to each bot's profile
- make user AI bot grid cards clickable and lead to the corresponding AI agent profile

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d532c9a1d48333841a8a5270427ee7