### PR TITLE
Add focus configuration step to AI agent creation flow

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -9,6 +9,7 @@ import AppShell from '@/components/AppShell';
 import GradientBackdrop from '@/components/ai-agent-create/GradientBackdrop';
 import Stepper from '@/components/ai-agent-create/Stepper';
 import IdentityStep from '@/components/ai-agent-create/IdentityStep';
+import FocusStep from '@/components/ai-agent-create/FocusStep';
 import VoiceStoryStep from '@/components/ai-agent-create/VoiceStoryStep';
 import MediaKitStep from '@/components/ai-agent-create/MediaKitStep';
 import PreviewSidebar from '@/components/ai-agent-create/PreviewSidebar';
@@ -53,7 +54,7 @@ export default function CreateAiAgentPage() {
     aiBotStore.resetFlow();
   };
 
-  const handleChange = (field: keyof FormState, value: string) => {
+  const handleChange = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     aiBotStore.setFormField(field, value);
   };
 
@@ -124,13 +125,17 @@ export default function CreateAiAgentPage() {
               )}
 
               {step === 1 && (
+                <FocusStep form={{ categories: form.categories, usefulness: form.usefulness }} onChange={handleChange} />
+              )}
+
+              {step === 2 && (
                 <VoiceStoryStep
                   form={{ prompt: form.prompt, description: form.description, intro: form.intro }}
                   onChange={handleChange}
                 />
               )}
 
-              {step === 2 && (
+              {step === 3 && (
                 <MediaKitStep
                   gallery={gallery}
                   maxItems={maxGalleryItems}

--- a/src/components/ai-agent-create/FocusStep.tsx
+++ b/src/components/ai-agent-create/FocusStep.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { FormState } from "@/helpers/types/agent-create";
+import { categoryOptions } from "@/helpers/data/agent-create";
+
+const normalized = (value: string) => value.trim().toLowerCase();
+
+type FocusForm = Pick<FormState, "categories" | "usefulness">;
+
+type FocusStepProps = {
+  form: FocusForm;
+  onChange: <K extends keyof FocusForm>(field: K, value: FocusForm[K]) => void;
+};
+
+export default function FocusStep({ form, onChange }: FocusStepProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const selectedMap = useMemo(
+    () => new Set(form.categories.map((item) => normalized(item))),
+    [form.categories],
+  );
+
+  const toggleCategory = (category: string) => {
+    const key = normalized(category);
+    const exists = selectedMap.has(key);
+    const next = exists
+      ? form.categories.filter((item) => normalized(item) !== key)
+      : [...form.categories, category];
+
+    onChange("categories", next);
+  };
+
+  const addUsefulness = () => {
+    const value = inputValue.trim();
+    if (!value) return;
+
+    const exists = form.usefulness.some((item) => normalized(item) === normalized(value));
+    if (exists) {
+      setInputValue("");
+      return;
+    }
+
+    onChange("usefulness", [...form.usefulness, value]);
+    setInputValue("");
+  };
+
+  const removeUsefulness = (value: string) => {
+    onChange(
+      "usefulness",
+      form.usefulness.filter((item) => item !== value),
+    );
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      addUsefulness();
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Define its focus</h2>
+        <p className="mt-2 text-sm text-white/70">
+          Choose the categories that match your agent and list out the situations where it shines.
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded-3xl border border-white/10 bg-neutral-900/70 p-6">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-white">Categories</span>
+          <span className="text-xs uppercase tracking-wide text-white/50">Pick multiple</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {categoryOptions.map((category) => {
+            const key = normalized(category);
+            const isSelected = selectedMap.has(key);
+            return (
+              <button
+                key={category}
+                type="button"
+                onClick={() => toggleCategory(category)}
+                className={`rounded-2xl border px-4 py-2 text-sm transition ${
+                  isSelected
+                    ? "border-violet-400/60 bg-violet-500/20 text-violet-100"
+                    : "border-white/15 bg-white/5 text-white/70 hover:border-violet-400/40 hover:bg-violet-500/10"
+                }`}
+              >
+                {category}
+              </button>
+            );
+          })}
+        </div>
+        {!form.categories.length && (
+          <p className="text-xs text-white/50">
+            Select at least one category to help others understand the agent&rsquo;s domain.
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-4 rounded-3xl border border-white/10 bg-neutral-900/70 p-6">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-white">Usefulness</span>
+          <span className="text-xs uppercase tracking-wide text-white/50">Add as many as you like</span>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <input
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Например: Быстрые брейнштормы"
+            className="flex-1 rounded-2xl border border-white/15 bg-neutral-900/80 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-violet-400 focus:outline-none"
+          />
+          <Button type="button" variant="primaryTight" onClick={addUsefulness} disabled={!inputValue.trim()}>
+            Добавить
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {form.usefulness.length ? (
+            form.usefulness.map((item) => (
+              <span
+                key={item}
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-white/80"
+              >
+                {item}
+                <button
+                  type="button"
+                  onClick={() => removeUsefulness(item)}
+                  className="rounded-full p-1 text-white/50 transition hover:bg-white/10 hover:text-white"
+                  aria-label={`Удалить ${item}`}
+                >
+                  <X className="size-3.5" />
+                </button>
+              </span>
+            ))
+          ) : (
+            <p className="text-xs text-white/50">Добавьте несколько вариантов, чтобы подсказать пользователям сценарии использования.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai-agent-create/IdentityStep.tsx
+++ b/src/components/ai-agent-create/IdentityStep.tsx
@@ -4,17 +4,21 @@
 import { Upload } from "lucide-react";
 import { FormState } from "../../helpers/types/agent-create";
 
+type IdentityForm = Pick<FormState, "firstName" | "lastName">;
+
+type IdentityStepProps = {
+  form: IdentityForm;
+  avatarPreview: string | null;
+  onAvatarChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: <K extends keyof IdentityForm>(field: K, value: IdentityForm[K]) => void;
+};
+
 export default function IdentityStep({
   form,
   avatarPreview,
   onAvatarChange,
   onChange,
-}: {
-  form: Pick<FormState, "firstName" | "lastName">;
-  avatarPreview: string | null;
-  onAvatarChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onChange: (field: keyof FormState, value: string) => void;
-}) {
+}: IdentityStepProps) {
   return (
     <div className="space-y-6">
       <div>

--- a/src/components/ai-agent-create/PreviewSidebar.tsx
+++ b/src/components/ai-agent-create/PreviewSidebar.tsx
@@ -56,6 +56,44 @@ export default function PreviewSidebar({
           </div>
         </div>
 
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-neutral-900/70 p-5">
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-white/60">Categories</h3>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {form.categories.length ? (
+                form.categories.map((category) => (
+                  <span
+                    key={category}
+                    className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70"
+                  >
+                    {category}
+                  </span>
+                ))
+              ) : (
+                <p className="text-xs text-white/50">Select categories to spotlight the agent&rsquo;s niche.</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-white/60">Usefulness</h3>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {form.usefulness.length ? (
+                form.usefulness.map((item) => (
+                  <span
+                    key={item}
+                    className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70"
+                  >
+                    {item}
+                  </span>
+                ))
+              ) : (
+                <p className="text-xs text-white/50">Add scenarios to illustrate how the agent helps.</p>
+              )}
+            </div>
+          </div>
+        </div>
+
         <div className="space-y-3">
           <div className="flex items-center justify-between text-xs uppercase tracking-wider text-white/50">
             <span>Gallery</span>

--- a/src/components/ai-agent-create/VoiceStoryStep.tsx
+++ b/src/components/ai-agent-create/VoiceStoryStep.tsx
@@ -2,14 +2,14 @@
 
 import { FormState } from "../../helpers/types/agent-create";
 
+type VoiceForm = Pick<FormState, "prompt" | "description" | "intro">;
 
-export default function VoiceStoryStep({
-  form,
-  onChange,
-}: {
-  form: Pick<FormState, "prompt" | "description" | "intro">;
-  onChange: (field: keyof FormState, value: string) => void;
-}) {
+type VoiceStoryStepProps = {
+  form: VoiceForm;
+  onChange: <K extends keyof VoiceForm>(field: K, value: VoiceForm[K]) => void;
+};
+
+export default function VoiceStoryStep({ form, onChange }: VoiceStoryStepProps) {
   return (
     <div className="space-y-6">
       <div>

--- a/src/helpers/data/agent-create.ts
+++ b/src/helpers/data/agent-create.ts
@@ -3,8 +3,18 @@ import { StepDef } from "../types/agent-create";
 
 export const steps: StepDef[] = [
   { title: "Identity", description: "Avatar, name, and the first impression." },
+  { title: "Focus", description: "Choose categories and the value it delivers." },
   { title: "Voice & Story", description: "Craft the agent prompt, description, and intro." },
   { title: "Media Kit", description: "Upload supporting visuals to set the mood." },
+];
+
+export const categoryOptions = [
+  "Обучение",
+  "Английский",
+  "Для прикола",
+  "Романтический",
+  "Роли",
+  "История",
 ];
 
 export const MAX_GALLERY_ITEMS = 6;

--- a/src/helpers/types/agent-create.ts
+++ b/src/helpers/types/agent-create.ts
@@ -4,6 +4,8 @@ export type FormState = {
   prompt: string;
   description: string;
   intro: string;
+  categories: string[];
+  usefulness: string[];
 };
 
 export type GalleryItem = {

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -26,6 +26,8 @@ export class AiBotStore extends BaseStore {
     prompt: '',
     description: '',
     intro: '',
+    categories: [],
+    usefulness: [],
   };
   avatar: File | null = null;
   avatarPreview: string | null = null;
@@ -81,21 +83,24 @@ export class AiBotStore extends BaseStore {
   }
 
   get currentStepComplete(): boolean {
-    if (this.step === 0) {
-      return Boolean(
-        this.form.firstName.trim() &&
-        this.form.lastName.trim() &&
-        (this.avatar !== null || this.avatarPreview !== null),
-      );
+    switch (this.step) {
+      case 0:
+        return Boolean(
+          this.form.firstName.trim() &&
+            this.form.lastName.trim() &&
+            (this.avatar !== null || this.avatarPreview !== null),
+        );
+      case 1:
+        return this.form.categories.length > 0 && this.form.usefulness.length > 0;
+      case 2:
+        return Boolean(
+          this.form.prompt.trim() &&
+            this.form.description.trim() &&
+            this.form.intro.trim(),
+        );
+      default:
+        return this.gallery.length > 0;
     }
-    if (this.step === 1) {
-      return Boolean(
-        this.form.prompt.trim() &&
-        this.form.description.trim() &&
-        this.form.intro.trim(),
-      );
-    }
-    return this.gallery.length > 0;
   }
 
   setStep(step: number) {
@@ -106,7 +111,7 @@ export class AiBotStore extends BaseStore {
     this.notify();
   }
 
-  setFormField(field: keyof FormState, value: string) {
+  setFormField<K extends keyof FormState>(field: K, value: FormState[K]) {
     this.form = { ...this.form, [field]: value };
     this.notify();
   }
@@ -171,7 +176,15 @@ export class AiBotStore extends BaseStore {
 
   resetFlow() {
     revokeGallery(this.gallery);
-    this.form = { firstName: '', lastName: '', prompt: '', description: '', intro: '' };
+    this.form = {
+      firstName: '',
+      lastName: '',
+      prompt: '',
+      description: '',
+      intro: '',
+      categories: [],
+      usefulness: [],
+    };
     this.avatar = null;
     this.replaceAvatarPreview(null);
     this.gallery = [];
@@ -323,6 +336,12 @@ export class AiBotStore extends BaseStore {
     if (intro) {
       formData.append('intro', intro);
       formData.append('introMessage', intro);
+    }
+    if (this.form.categories.length) {
+      formData.append('categories', JSON.stringify(this.form.categories));
+    }
+    if (this.form.usefulness.length) {
+      formData.append('usefulness', JSON.stringify(this.form.usefulness));
     }
     if (this.avatar) {
       formData.append('avatar', this.avatar);


### PR DESCRIPTION
## Summary
- introduce a new Focus step in the AI agent creation wizard with category multi-select and usefulness tag input
- extend form state, store logic, and preview sidebar to surface the new metadata
- include the focus selections when submitting the creation payload

## Testing
- npm run lint *(fails: existing lint/type issues across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6451fbc2c8333a55f92ce7beded1b