### PR TITLE
Add follow toggling for AI agent profiles

### DIFF
--- a/src/components/ai-agent/ActionButtons.tsx
+++ b/src/components/ai-agent/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { MessageCircle, UserPlus, Share2 } from "lucide-react";
+import { Check, MessageCircle, Share2, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 
 
@@ -25,17 +25,50 @@ export default function ActionButtons({
 }
 
 
-export function PrimaryCTAs({ chatHref }: { chatHref: string }) {
-    return (
-        <div className="flex flex-col gap-3 md:flex-row">
-            <div className="flex flex-1">
-                <Button variant="primary">
-                    <UserPlus className="size-4" /> Follow
-                </Button>
-            </div>
-            <Link href={chatHref} className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5">
-                <MessageCircle className="size-4" /> Chat with aiAgent
-            </Link>
-        </div>
-    );
+interface PrimaryCTAProps {
+  chatHref: string;
+  isFollowing?: boolean;
+  isBusy?: boolean;
+  disableFollowAction?: boolean;
+  onToggleFollow?: () => void;
+}
+
+export function PrimaryCTAs({
+  chatHref,
+  isFollowing,
+  isBusy,
+  disableFollowAction,
+  onToggleFollow,
+}: PrimaryCTAProps) {
+  const isActionDisabled = disableFollowAction || isBusy || !onToggleFollow;
+  const buttonLabel = isBusy
+    ? "Processing..."
+    : isFollowing
+      ? "Subscribed"
+      : "Follow";
+  const ButtonIcon = isFollowing ? Check : UserPlus;
+  const buttonVariant = isFollowing ? "outline" : "primary";
+
+  return (
+    <div className="flex flex-col gap-3 md:flex-row">
+      <div className="flex flex-1">
+        <Button
+          variant={buttonVariant}
+          className="w-full justify-center"
+          disabled={isActionDisabled}
+          onClick={onToggleFollow}
+          aria-pressed={Boolean(isFollowing)}
+        >
+          <ButtonIcon className="size-4" />
+          {buttonLabel}
+        </Button>
+      </div>
+      <Link
+        href={chatHref}
+        className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5"
+      >
+        <MessageCircle className="size-4" /> Chat with aiAgent
+      </Link>
+    </div>
+  );
 }

--- a/src/helpers/types/dtos/AiBotDto.ts
+++ b/src/helpers/types/dtos/AiBotDto.ts
@@ -19,4 +19,5 @@ export interface AiBotDetails {
   categories?: string[];
   botId?: string;
   createdBy?: ProfileMinData;
+  isFollowing?: boolean;
 }

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -193,6 +193,13 @@ export class ProfileService {
   }
 
   /**
+   * Подписаться или отписаться от AI-бота по его идентификатору.
+   */
+  public async followAiBotById(id: string): Promise<AxiosResponse<{ followers: number; isFollowing: boolean }, any>> {
+    return $api.put(`/profile/ai-bots/${id}/follow`);
+  }
+
+  /**
    * Создать нового AI-бота. Для передачи аватара необходимо использовать FormData.
    */
   public async createAiBot(formData: FormData): Promise<AxiosResponse<UserDTO, any>> {


### PR DESCRIPTION
## Summary
- surface AI agent follow status on the client profile view and disable actions when unauthenticated
- add follow/unfollow handler that reuses the existing store and service plumbing to keep follower counts in sync
- extend DTOs and follow button component so the UI reflects whether the user is already subscribed

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6649cf55c83339f39fa35eda00f77