### PR TITLE
Refresh auth tokens when the store provider mounts

### DIFF
--- a/src/stores/StoreProvider.tsx
+++ b/src/stores/StoreProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useRef, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, type ReactNode } from 'react';
 import { useSyncExternalStore } from 'react';
 import { RootStore } from './RootStore';
 import { BaseStore } from './BaseStore';
@@ -12,6 +12,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   if (!storeRef.current) {
     storeRef.current = new RootStore();
   }
+  useEffect(() => {
+    void storeRef.current?.authStore.refreshAccessToken();
+  }, []);
   return <StoreContext.Provider value={storeRef.current}>{children}</StoreContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary
- trigger a refresh of the auth tokens when the StoreProvider initializes so sessions persist after reload

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d66c4d85f883338c8f226c641cba85