### PR TITLE
Fix follow button state for AI agent profiles

### DIFF
--- a/src/app/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -81,7 +81,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
 
   const chatHref = aiBot?.chatLink || routes.adminChat;
   const aiBotProfileId = aiBot?._id;
-  const isFollowing = Boolean(botDetails?.isFollowing);
+  const isFollowing = botDetails?.isFollowing ?? aiBot?.isFollowing ?? false;
   const disableFollowAction = !isAuthenticated || !aiBotProfileId;
 
   const isCreator = useMemo(() => {

--- a/src/helpers/types/dtos/AiBotDto.ts
+++ b/src/helpers/types/dtos/AiBotDto.ts
@@ -9,6 +9,7 @@ export interface AiBotDTO extends UserDTO {
   botId: string;
   createdBy: ProfileMinData;
   aiPrompt: string;
+  isFollowing?: boolean;
 }
 
 export interface AiBotDetails {

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -324,7 +324,7 @@ export class AiBotStore extends BaseStore {
         this.bots = updateFollowers(this.bots);
 
         if (this.selectAiBot && this.selectAiBot._id === id) {
-          this.selectAiBot = { ...this.selectAiBot, followers: data.followers };
+          this.selectAiBot = { ...this.selectAiBot, followers: data.followers, isFollowing: data.isFollowing };
         }
 
         if (this.botDetails) {


### PR DESCRIPTION
## Summary
- fall back to the AI bot profile payload when deciding if the current user already follows an agent
- keep the selected AI bot's follow state in sync after follow/unfollow mutations
- type the AiBotDTO to expose the optional isFollowing flag returned by the API

## Testing
- npm run lint *(fails: pre-existing lint errors about any/unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d66dce63c88333a984e15e1db9c8ec