### PR TITLE
Refactor AI listings to use CardRailOneRow

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -8,7 +8,8 @@ import AppShell from "@/components/AppShell";
 import GradientBackdrop from "@/components/user/GradientBackdrop";
 import HeaderBar from "@/components/user/HeaderBar";
 import SectionHeader from "@/components/user/SectionHeader";
-import AiBotGrid from "@/components/user/AiBotGrid";
+import CardRailOneRow from "@/components/ui/CardRailOneRow";
+import AiBotCard from "@/components/user/AiBotCard";
 import ProfileCard from "@/components/profile/ProfileCard";
 
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
@@ -101,7 +102,19 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               subtitle={"Персональные напарники, созданные этим пользователем."}
               actionLabel="View archive"
             />
-            <AiBotGrid items={userAiBots} isLoading={isLoadingAiBot} />
+            <CardRailOneRow
+              items={userAiBots}
+              isLoading={isLoadingAiBot}
+              loadingMessage="Загружаем подборку AI-ботов…"
+              emptyMessage="Пока что здесь пусто — добавьте своего первого AI-бота, чтобы показать его миру."
+              cardWidth={280}
+              gap={18}
+              contentClassName="mt-2"
+              gridClassName="p-0 gap-4 md:gap-6"
+              itemClassName="h-full"
+              renderItem={(bot) => <AiBotCard bot={bot} />}
+              getItemKey={(bot) => bot._id}
+            />
             {(isLoadingProfile || isLoadingAiBot) && (
               <p className="text-sm text-white/60">Loading profile…</p>
             )}

--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -1,3 +1,4 @@
+import CardRailOneRow from "@/components/ui/CardRailOneRow";
 import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
 import AiAgentCard from "./AiAgentCard";
 
@@ -9,21 +10,27 @@ type AiAgentsTimelineProps = {
 };
 
 export default function AiAgentsTimeline({ items, title, description, emptyMessage }: AiAgentsTimelineProps) {
-  const hasItems = items.length > 0;
+  const resolvedEmptyMessage = emptyMessage ?? "No AI agents to display yet.";
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-      <h2 className="text-lg font-semibold text-white">{title}</h2>
-      <p className="mt-2 text-sm text-white/70">{description}</p>
-      <div className="mt-6 space-y-4">
-        {hasItems ? (
-          items.map((aiAgent) => <AiAgentCard key={aiAgent._id ?? aiAgent.name} aiAgent={aiAgent} />)
-        ) : (
-          <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
-            {emptyMessage ?? "No AI agents to display yet."}
-          </p>
-        )}
-      </div>
-    </section>
+    <CardRailOneRow<AiBotDTO>
+      items={items}
+      title={title}
+      description={description}
+      titleAdornment={null}
+      emptyMessage={
+        <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
+          {resolvedEmptyMessage}
+        </p>
+      }
+      className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+      contentClassName="mt-6"
+      cardWidth={320}
+      gap={20}
+      gridClassName="p-0"
+      itemClassName="h-full"
+      renderItem={(aiAgent) => <AiAgentCard aiAgent={aiAgent} />}
+      getItemKey={(aiAgent) => aiAgent._id ?? aiAgent.name}
+    />
   );
 }

--- a/src/components/ui/CardRailOneRow.tsx
+++ b/src/components/ui/CardRailOneRow.tsx
@@ -1,34 +1,63 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import { Button } from '@/components/ui/Button';
 import HoverSwapCard from '../AiCard';
 
-type Item = {
-  id: string | number;
-  src: string;
+type CardRailItem = {
+  id?: string | number;
+  src?: string;
   avatarSrc?: string;
-  title: string;
+  title?: string;
   views?: number | string;
   hoverText?: string;
   href?: string;
 };
 
-type Props = {
-  items: Item[];
-  title?: string;       // 🔑 новый проп для заголовка
-  cardWidth?: number;   // px
-  gap?: number;         // px
+type CardRailOneRowProps<T extends CardRailItem = CardRailItem> = {
+  items: T[];
+  title?: string;
+  description?: ReactNode;
+  titleAdornment?: ReactNode;
+  isLoading?: boolean;
+  loadingMessage?: ReactNode;
+  emptyMessage?: ReactNode;
+  cardWidth?: number;
+  gap?: number;
   className?: string;
+  contentClassName?: string;
+  scrollerClassName?: string;
+  gridClassName?: string;
+  itemClassName?: string;
+  showNavigationButtons?: boolean;
+  renderItem?: (item: T, index: number) => ReactNode;
+  getItemKey?: (item: T, index: number) => string | number;
 };
 
-export default function CardRailOneRow({
+const defaultMessageClassName =
+  'rounded-3xl border border-white/10 bg-neutral-900/60 p-6 text-sm text-white/60';
+
+const defaultTitleAdornment = <span className="text-yellow-400">✨</span>;
+
+export default function CardRailOneRow<T extends CardRailItem = CardRailItem>({
   items,
   title,
+  description,
+  titleAdornment,
+  isLoading = false,
+  loadingMessage = 'Loading…',
+  emptyMessage = 'No items to display yet.',
   cardWidth = 220,
   gap = 16,
   className = '',
-}: Props) {
+  contentClassName = '',
+  scrollerClassName = '',
+  gridClassName = '',
+  itemClassName = '',
+  showNavigationButtons = true,
+  renderItem,
+  getItemKey,
+}: CardRailOneRowProps<T>) {
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   const scrollBy = (dir: 1 | -1) => {
@@ -38,64 +67,110 @@ export default function CardRailOneRow({
     });
   };
 
+  const resolvedTitleAdornment =
+    titleAdornment === undefined ? defaultTitleAdornment : titleAdornment;
+
+  const hasHeader = Boolean(title || description);
+  const hasItems = items.length > 0;
+  const shouldShowNav =
+    showNavigationButtons && hasItems && items.length > 1 && !isLoading;
+
+  const defaultRenderItem = (item: CardRailItem) => (
+    <HoverSwapCard
+      src={item.src ?? ''}
+      avatarSrc={item.avatarSrc}
+      title={item.title ?? ''}
+      views={item.views}
+      hoverText={item.hoverText}
+      href={item.href}
+    />
+  );
+
+  const renderCard = renderItem ?? (defaultRenderItem as (item: T, index: number) => ReactNode);
+  const getKey =
+    getItemKey ??
+    ((item: T, index: number) => {
+      if (typeof item === 'object' && item !== null && 'id' in item && item.id !== undefined) {
+        return item.id as string | number;
+      }
+
+      return index;
+    });
+
+  const renderMessage = (message: ReactNode) =>
+    typeof message === 'string' ? (
+      <div className={defaultMessageClassName}>{message}</div>
+    ) : (
+      message
+    );
+
+  let content: ReactNode;
+
+  if (isLoading) {
+    content = renderMessage(loadingMessage);
+  } else if (!hasItems) {
+    content = renderMessage(emptyMessage);
+  } else {
+    content = (
+      <>
+        {shouldShowNav && (
+          <div className="hidden md:flex absolute left-2 top-1/2 z-10 -translate-y-1/2">
+            <Button aria-label="Previous" onClick={() => scrollBy(-1)} variant="carouselNav">
+              ‹
+            </Button>
+          </div>
+        )}
+        {shouldShowNav && (
+          <div className="hidden md:flex absolute right-2 top-1/2 z-10 -translate-y-1/2">
+            <Button aria-label="Next" onClick={() => scrollBy(1)} variant="carouselNav">
+              ›
+            </Button>
+          </div>
+        )}
+        <div
+          ref={scrollerRef}
+          className={`overflow-x-auto overflow-y-hidden [scrollbar-width:none] [-ms-overflow-style:none] snap-x snap-mandatory ${scrollerClassName}`}
+          style={{ scrollBehavior: 'smooth' }}
+        >
+          <style>{` div::-webkit-scrollbar { display: none; } `}</style>
+
+          <div
+            className={`grid grid-rows-1 auto-cols-max [grid-auto-flow:column] gap-4 md:gap-5 p-2 md:p-3 ${gridClassName}`}
+            style={{
+              gridAutoColumns: `${cardWidth}px`,
+              columnGap: `${gap}px`,
+            }}
+          >
+            {items.map((item, index) => (
+              <div key={getKey(item, index)} className={`snap-start ${itemClassName}`}>
+                {renderCard(item, index)}
+              </div>
+            ))}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  const contentWrapperClassName = [hasHeader ? 'mt-4' : '', contentClassName]
+    .join(' ')
+    .trim();
+
   return (
     <section className={`relative ${className}`}>
-      {/* Заголовок */}
-      {title && (
-        <h2 className="mb-3 text-lg font-semibold text-white flex items-center gap-2">
-          {title}
-          <span className="text-yellow-400">✨</span>
-        </h2>
+      {hasHeader && (
+        <div className="flex flex-col gap-1">
+          {title && (
+            <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+              {title}
+              {resolvedTitleAdornment}
+            </h2>
+          )}
+          {description && <p className="text-sm text-white/70">{description}</p>}
+        </div>
       )}
 
-      {/* Кнопки пролистывания */}
-      <div className="hidden md:flex absolute left-2 top-1/2 z-10 -translate-y-1/2">
-        <Button aria-label="Prev" onClick={() => scrollBy(-1)} variant="carouselNav">
-          ‹
-        </Button>
-      </div>
-      <div className="hidden md:flex absolute right-2 top-1/2 z-10 -translate-y-1/2">
-        <Button aria-label="Next" onClick={() => scrollBy(1)} variant="carouselNav">
-          ›
-        </Button>
-      </div>
-
-      {/* Скроллер */}
-      <div
-        ref={scrollerRef}
-        className="overflow-x-auto overflow-y-hidden [scrollbar-width:none] [-ms-overflow-style:none] snap-x snap-mandatory"
-        style={{ scrollBehavior: 'smooth' }}
-      >
-        <style>{` div::-webkit-scrollbar { display: none; } `}</style>
-
-        <div
-          className="
-            grid
-            grid-rows-1
-            auto-cols-max
-            [grid-auto-flow:column]
-            gap-4 md:gap-5
-            p-2 md:p-3
-          "
-          style={{
-            gridAutoColumns: `${cardWidth}px`,
-            columnGap: `${gap}px`,
-          }}
-        >
-          {items.map((it) => (
-            <div key={it.id} className="snap-start">
-              <HoverSwapCard
-                src={it.src}
-                avatarSrc={it.avatarSrc}
-                title={it.title}
-                views={it.views}
-                hoverText={it.hoverText}
-                href={it.href}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
+      <div className={contentWrapperClassName}>{content}</div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- expand `CardRailOneRow` to support custom renderers, loading and empty states, and optional descriptions
- reuse the rail in `AiAgentsTimeline` to show AI agents with horizontal scrolling cards
- replace `AiBotGrid` usage on the user profile page with the rail-based carousel of `AiBotCard`s

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c9c8c63c8333bb96a8028a7df5da