### PR TITLE
Use HoverSwapCard in profile rails

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -9,10 +9,10 @@ import GradientBackdrop from "@/components/user/GradientBackdrop";
 import HeaderBar from "@/components/user/HeaderBar";
 import SectionHeader from "@/components/user/SectionHeader";
 import CardRailOneRow from "@/components/ui/CardRailOneRow";
-import AiBotCard from "@/components/user/AiBotCard";
 import ProfileCard from "@/components/profile/ProfileCard";
 
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
+import { mapAiBotsToHoverSwapCards } from "@/helpers/utils/aiBot";
 
 interface UserProfilePageProps {
   profileId?: string;
@@ -31,6 +31,7 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
 
   const userAiBots = useStoreData(aiBotStore, (store) => store.userAiBots);
   const isLoadingAiBot = useStoreData(aiBotStore, (store) => store.isAiUserLoading);
+  const botCards = mapAiBotsToHoverSwapCards(userAiBots);
 
   const [isUpdatingFollow, setIsUpdatingFollow] = useState(false);
 
@@ -103,7 +104,7 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               actionLabel="View archive"
             />
             <CardRailOneRow
-              items={userAiBots}
+              items={botCards}
               isLoading={isLoadingAiBot}
               loadingMessage="Загружаем подборку AI-ботов…"
               emptyMessage="Пока что здесь пусто — добавьте своего первого AI-бота, чтобы показать его миру."
@@ -112,8 +113,6 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               contentClassName="mt-2"
               gridClassName="p-0 gap-4 md:gap-6"
               itemClassName="h-full"
-              renderItem={(bot) => <AiBotCard bot={bot} />}
-              getItemKey={(bot) => bot._id}
             />
             {(isLoadingProfile || isLoadingAiBot) && (
               <p className="text-sm text-white/60">Loading profile…</p>

--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -1,6 +1,6 @@
 import CardRailOneRow from "@/components/ui/CardRailOneRow";
 import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
-import AiAgentCard from "./AiAgentCard";
+import { mapAiBotsToHoverSwapCards } from "@/helpers/utils/aiBot";
 
 type AiAgentsTimelineProps = {
   items: AiBotDTO[];
@@ -11,10 +11,11 @@ type AiAgentsTimelineProps = {
 
 export default function AiAgentsTimeline({ items, title, description, emptyMessage }: AiAgentsTimelineProps) {
   const resolvedEmptyMessage = emptyMessage ?? "No AI agents to display yet.";
+  const cardItems = mapAiBotsToHoverSwapCards(items);
 
   return (
-    <CardRailOneRow<AiBotDTO>
-      items={items}
+    <CardRailOneRow
+      items={cardItems}
       title={title}
       description={description}
       titleAdornment={null}
@@ -29,8 +30,6 @@ export default function AiAgentsTimeline({ items, title, description, emptyMessa
       gap={20}
       gridClassName="p-0"
       itemClassName="h-full"
-      renderItem={(aiAgent) => <AiAgentCard aiAgent={aiAgent} />}
-      getItemKey={(aiAgent) => aiAgent._id ?? aiAgent.name}
     />
   );
 }

--- a/src/helpers/utils/aiBot.ts
+++ b/src/helpers/utils/aiBot.ts
@@ -1,0 +1,54 @@
+import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
+import { getUserAvatar } from "@/helpers/utils/user";
+
+const DEFAULT_DESCRIPTION = "Описание пока отсутствует.";
+
+type HoverSwapCardItem = {
+  id: string;
+  src: string;
+  avatarSrc: string;
+  title: string;
+  views?: number | string;
+  hoverText?: string;
+  href: string;
+};
+
+const resolveIdentifier = (bot: AiBotDTO) =>
+  bot._id ?? bot.botId ?? bot.username ?? bot.name ?? "unknown";
+
+const buildBotHref = (bot: AiBotDTO) => {
+  const identifier = resolveIdentifier(bot);
+
+  return `/profile/ai-agent/${encodeURIComponent(identifier)}`;
+};
+
+const getBotDescription = (bot: AiBotDTO) => {
+  const description = bot.intro?.trim() || bot.userBio?.trim();
+
+  return description && description.length > 0 ? description : DEFAULT_DESCRIPTION;
+};
+
+const getPrimaryImage = (bot: AiBotDTO, fallback: string) => {
+  const [firstPhoto] = bot.photos ?? [];
+
+  return firstPhoto ?? fallback;
+};
+
+export const mapAiBotToHoverSwapCard = (bot: AiBotDTO): HoverSwapCardItem => {
+  const avatar = getUserAvatar(bot);
+  const identifier = resolveIdentifier(bot);
+
+  return {
+    id: identifier.toString(),
+    src: getPrimaryImage(bot, avatar),
+    avatarSrc: avatar,
+    title: bot.name ?? "AI Companion",
+    views: typeof bot.followers === "number" ? bot.followers.toLocaleString("ru-RU") : undefined,
+    hoverText: getBotDescription(bot),
+    href: buildBotHref(bot),
+  };
+};
+
+export const mapAiBotsToHoverSwapCards = (bots: AiBotDTO[]): HoverSwapCardItem[] =>
+  bots.map((bot) => mapAiBotToHoverSwapCard(bot));
+


### PR DESCRIPTION
## Summary
- map AI bot data into HoverSwapCard-friendly objects for profile rails
- switch the user and my profile AI bot sections to render HoverSwapCard items within the scroller
- add a reusable helper for formatting AI bot data used by both profile pages

## Testing
- npm run lint *(fails: existing lint issues across unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ccebc058833390db35237e8aebe1