### PR TITLE
Adjust profile grids for responsive HoverSwapCard layout

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -8,7 +8,7 @@ import AppShell from "@/components/AppShell";
 import GradientBackdrop from "@/components/user/GradientBackdrop";
 import HeaderBar from "@/components/user/HeaderBar";
 import SectionHeader from "@/components/user/SectionHeader";
-import CardRailOneRow from "@/components/ui/CardRailOneRow";
+import HoverSwapCard from "@/components/AiCard";
 import ProfileCard from "@/components/profile/ProfileCard";
 
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
@@ -103,17 +103,32 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               subtitle={"Персональные напарники, созданные этим пользователем."}
               actionLabel="View archive"
             />
-            <CardRailOneRow
-              items={botCards}
-              isLoading={isLoadingAiBot}
-              loadingMessage="Загружаем подборку AI-ботов…"
-              emptyMessage="Пока что здесь пусто — добавьте своего первого AI-бота, чтобы показать его миру."
-              cardWidth={280}
-              gap={18}
-              contentClassName="mt-2"
-              gridClassName="p-0 gap-4 md:gap-6"
-              itemClassName="h-full"
-            />
+            <div className="mt-2">
+              {isLoadingAiBot ? (
+                <p className="rounded-3xl border border-white/10 bg-neutral-900/60 p-6 text-center text-sm text-white/60">
+                  Загружаем подборку AI-ботов…
+                </p>
+              ) : botCards.length > 0 ? (
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-6 xl:grid-cols-4">
+                  {botCards.map((item) => (
+                    <div key={item.id} className="flex justify-center sm:justify-start">
+                      <HoverSwapCard
+                        src={item.src}
+                        avatarSrc={item.avatarSrc}
+                        title={item.title}
+                        views={item.views}
+                        hoverText={item.hoverText}
+                        href={item.href}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="rounded-3xl border border-white/10 bg-neutral-900/60 p-6 text-center text-sm text-white/60">
+                  Пока что здесь пусто — добавьте своего первого AI-бота, чтобы показать его миру.
+                </p>
+              )}
+            </div>
             {(isLoadingProfile || isLoadingAiBot) && (
               <p className="text-sm text-white/60">Loading profile…</p>
             )}

--- a/src/components/AiCard.tsx
+++ b/src/components/AiCard.tsx
@@ -29,7 +29,10 @@ export default function HoverSwapCard({
   href,
 }: HoverSwapCardProps) {
   const CardInner = (
-    <div className="group relative isolate w-[220px] h-[280px] overflow-hidden rounded-3xl bg-zinc-900 shadow-xl ring-1 ring-black/10 hover:ring-black/20 transition-all">
+    <div
+      className="group relative isolate w-full max-w-[260px] overflow-hidden rounded-3xl bg-zinc-900 shadow-xl ring-1 ring-black/10 transition-all hover:ring-black/20"
+      style={{ aspectRatio: "11 / 14" }}
+    >
       {/* Image */}
       <img
         src={src}

--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -1,35 +1,55 @@
-import CardRailOneRow from "@/components/ui/CardRailOneRow";
+import HoverSwapCard from "@/components/AiCard";
 import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
 import { mapAiBotsToHoverSwapCards } from "@/helpers/utils/aiBot";
+import { ReactNode } from "react";
 
 type AiAgentsTimelineProps = {
   items: AiBotDTO[];
   title: string;
   description: string;
-  emptyMessage?: string;
+  emptyMessage?: ReactNode;
 };
 
 export default function AiAgentsTimeline({ items, title, description, emptyMessage }: AiAgentsTimelineProps) {
   const resolvedEmptyMessage = emptyMessage ?? "No AI agents to display yet.";
   const cardItems = mapAiBotsToHoverSwapCards(items);
 
+  const renderMessage = (message: ReactNode) =>
+    typeof message === "string" ? (
+      <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
+        {message}
+      </p>
+    ) : (
+      message
+    );
+
   return (
-    <CardRailOneRow
-      items={cardItems}
-      title={title}
-      description={description}
-      titleAdornment={null}
-      emptyMessage={
-        <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
-          {resolvedEmptyMessage}
-        </p>
-      }
-      className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur"
-      contentClassName="mt-6"
-      cardWidth={320}
-      gap={20}
-      gridClassName="p-0"
-      itemClassName="h-full"
-    />
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-white">{title}</h2>
+        <p className="text-sm text-white/70">{description}</p>
+      </div>
+
+      <div className="mt-6">
+        {cardItems.length > 0 ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-6 xl:grid-cols-4">
+            {cardItems.map((item) => (
+              <div key={item.id} className="flex justify-center sm:justify-start">
+                <HoverSwapCard
+                  src={item.src}
+                  avatarSrc={item.avatarSrc}
+                  title={item.title}
+                  views={item.views}
+                  hoverText={item.hoverText}
+                  href={item.href}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          renderMessage(resolvedEmptyMessage)
+        )}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the carousel-based AI agent rail on profile pages with a responsive HoverSwapCard grid
- update the shared AI agents timeline component to render cards without horizontal scrolling and preserve empty-state messaging
- ensure the HoverSwapCard grid keeps two columns on mobile, centers cards, and prevents overlap with added spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d098d0c08333acc23425deaf4e4c