### PR TITLE
Use HoverSwapCard for profile timelines

### DIFF
--- a/src/app/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/profile/user/[id]/ClientUserProfilePage.tsx
@@ -7,8 +7,7 @@ import AppShell from "@/components/AppShell";
 
 import GradientBackdrop from "@/components/user/GradientBackdrop";
 import HeaderBar from "@/components/user/HeaderBar";
-import SectionHeader from "@/components/user/SectionHeader";
-import AiBotGrid from "@/components/user/AiBotGrid";
+import AiAgentsTimeline from "@/components/profile/AiAgentsTimeline";
 import ProfileCard from "@/components/profile/ProfileCard";
 
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
@@ -96,13 +95,14 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
           </header>
 
           <section className="mt-12 space-y-6">
-            <SectionHeader
+            <AiAgentsTimeline
+              items={userAiBots}
+              isLoading={isLoadingAiBot}
               title="AI Companions"
-              subtitle={"Персональные напарники, созданные этим пользователем."}
-              actionLabel="View archive"
+              description="Персональные напарники, созданные этим пользователем."
+              emptyMessage="Пока что здесь пусто — добавьте своего первого AI-бота, чтобы показать его миру."
             />
-            <AiBotGrid items={userAiBots} isLoading={isLoadingAiBot} />
-            {(isLoadingProfile || isLoadingAiBot) && (
+            {isLoadingProfile && (
               <p className="text-sm text-white/60">Loading profile…</p>
             )}
           </section>

--- a/src/components/AiCard.tsx
+++ b/src/components/AiCard.tsx
@@ -29,7 +29,7 @@ export default function HoverSwapCard({
   href,
 }: HoverSwapCardProps) {
   const CardInner = (
-    <div className="group relative isolate w-[220px] h-[280px] overflow-hidden rounded-3xl bg-zinc-900 shadow-xl ring-1 ring-black/10 hover:ring-black/20 transition-all">
+    <div className="group relative isolate w-full max-w-[220px] aspect-[11/14] overflow-hidden rounded-3xl bg-zinc-900 shadow-xl ring-1 ring-black/10 transition-all hover:ring-black/20">
       {/* Image */}
       <img
         src={src}

--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -1,27 +1,80 @@
-import { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
-import AiAgentCard from "./AiAgentCard";
+import HoverSwapCard from "@/components/AiCard";
+import { getUserAvatar } from "@/helpers/utils/user";
+import type { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
+import type { UserDTO } from "@/helpers/types";
+
+type TimelineAgent = AiBotDTO | UserDTO;
 
 type AiAgentsTimelineProps = {
-  items: AiBotDTO[];
+  items: TimelineAgent[];
   title: string;
   description: string;
   emptyMessage?: string;
+  isLoading?: boolean;
 };
 
-export default function AiAgentsTimeline({ items, title, description, emptyMessage }: AiAgentsTimelineProps) {
+const formatFollowers = (count?: number) =>
+  typeof count === "number" ? count.toLocaleString("ru-RU") : undefined;
+
+const getCoverImage = (agent: TimelineAgent) => {
+  if ("photos" in agent && Array.isArray(agent.photos) && agent.photos.length > 0) {
+    return agent.photos[0];
+  }
+
+  return getUserAvatar(agent);
+};
+
+const getHoverDescription = (agent: TimelineAgent) => {
+  if ("intro" in agent && agent.intro) {
+    return agent.intro;
+  }
+
+  return agent.userBio ?? agent.aiPrompt ?? undefined;
+};
+
+export default function AiAgentsTimeline({
+  items,
+  title,
+  description,
+  emptyMessage,
+  isLoading = false,
+}: AiAgentsTimelineProps) {
   const hasItems = items.length > 0;
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-      <h2 className="text-lg font-semibold text-white">{title}</h2>
-      <p className="mt-2 text-sm text-white/70">{description}</p>
-      <div className="mt-6 space-y-4">
-        {hasItems ? (
-          items.map((aiAgent) => <AiAgentCard key={aiAgent._id ?? aiAgent.name} aiAgent={aiAgent} />)
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold text-white">{title}</h2>
+        <p className="text-sm text-white/70">{description}</p>
+      </div>
+
+      <div className="mt-6">
+        {isLoading && !hasItems ? (
+          <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
+            Загружаем подборку AI-агентов…
+          </p>
+        ) : hasItems ? (
+          <div className="grid grid-cols-2 place-items-center gap-4 sm:gap-6 md:grid-cols-3 xl:grid-cols-4">
+            {items.map((aiAgent) => (
+              <HoverSwapCard
+                key={aiAgent._id ?? aiAgent.name}
+                src={getCoverImage(aiAgent)}
+                avatarSrc={getUserAvatar(aiAgent)}
+                title={aiAgent.name}
+                views={formatFollowers(aiAgent.followers)}
+                hoverText={getHoverDescription(aiAgent)}
+                href={`/profile/ai-agent/${encodeURIComponent(aiAgent._id)}`}
+              />
+            ))}
+          </div>
         ) : (
           <p className="rounded-2xl border border-dashed border-white/15 bg-transparent px-4 py-8 text-center text-sm text-white/60">
             {emptyMessage ?? "No AI agents to display yet."}
           </p>
+        )}
+
+        {isLoading && hasItems && (
+          <p className="mt-4 text-center text-xs text-white/50">Обновляем список…</p>
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- swap the AI agent timeline cards to use the HoverSwapCard component for both my profile and user profile pages
- update the timeline layout to a responsive grid with spacing so cards no longer overlap and show two per row on small screens
- tweak HoverSwapCard sizing so it scales within the new grid without clipping

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dc8edc8c833393170112feb6147b