### PR TITLE
Adjust AI agent grid columns for mobile profile views

### DIFF
--- a/src/components/profile/AiAgentsTimeline.tsx
+++ b/src/components/profile/AiAgentsTimeline.tsx
@@ -68,7 +68,7 @@ export default function AiAgentsTimeline({
             Загружаем подборку AI-агентов…
           </p>
         ) : hasItems ? (
-          <div className="grid grid-cols-3 gap-6 items-stretch">
+          <div className="grid grid-cols-2 gap-6 items-stretch md:grid-cols-3">
             {items.map((aiAgent) => (
               <HoverSwapCard
                 key={(aiAgent as any)._id ?? aiAgent.name}


### PR DESCRIPTION
## Summary
- update the AI agents timeline grid to use two columns on small screens so HoverSwapCard displays two items on profile pages
- retain three-column layout on medium and larger screens for MyProfilePage and UserProfilePage

## Testing
- npm run dev *(fails: missing peer dependencies like axios in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e2a5b4f88333833534b97612ee42