### PR TITLE
feat: add admin editor for AI catalog

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,75 +1,269 @@
 'use client';
 
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import CardRailTwoRows from "@/components/ui/CardRailTwoRows";
 import AppShell from "@/components/AppShell";
 import CardRailOneRow from "@/components/ui/CardRailOneRow";
-import { Spacer } from "@/components/ui/Spacer";
+import { Button } from "@/components/ui/Button";
+import { useAuthRoutes, type AuthRouteKey } from "@/helpers/hooks/useAuthRoutes";
+import { useRootStore, useStoreData } from "@/stores/StoreProvider";
+import type { CatalogItem } from "@/stores/CatalogStore";
 
-// export const metadata = {
-//   title: 'AI Pair — Talk with an AI companion',
-// }
+type CardRailDisplayItem = Omit<CatalogItem, 'routeKey'> & { href: string };
 
-const data = [
-  { id: 0, cardWidth: "200", src: '/img/mizuhara.png', title: 'aiAgent α', views: 'Profile', hoverText: 'View the creator dossier.', href: '/profile/ai-agent' },
-  { id: 1, cardWidth: "200", src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 2, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 3, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 4, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 5, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 6, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 7, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 8, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 9, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 10, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 11, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 12, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 13, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 14, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 15, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 16, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 17, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 18, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 19, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 20, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  { id: 21, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', href: '/admin/chat' },
-  { id: 22, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', href: '/admin/chat' },
-  // ...добавляй дальше сколько нужно
-];
+const inputClasses =
+  "w-full rounded-2xl border border-white/10 bg-black/60 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-violet-500/60";
 
-// Tailwind is assumed available in the preview. Primary brand color from your prefs: #6f2da8
-// Minimalistic, fast, single-file landing you can paste into a Next.js page or CRA component.
-// Sections: Nav, Hero, SocialProof, Features, Demo, Pricing, FAQ, Footer.
+const labelClasses = "text-xs font-medium uppercase tracking-wide text-white/50";
+
+function renderPreviewItems(
+  items: CatalogItem[],
+  mapToCardRailItems: (items: CatalogItem[]) => CardRailDisplayItem[],
+): CardRailDisplayItem[] {
+  if (!items.length) {
+    return [
+      {
+        id: 'empty',
+        title: 'No cards yet',
+        hoverText: 'Use the editor below to add your first AI.',
+        src: '',
+        href: '#',
+      },
+    ];
+  }
+  return mapToCardRailItems(items);
+}
 
 export default function Landing() {
+  const { routes } = useAuthRoutes();
+  const { catalogStore } = useRootStore();
+  const categories = useStoreData(catalogStore, (store) => store.categories);
+  const featuredCategoryId = useStoreData(catalogStore, (store) => store.featuredCategoryId);
+  const featuredItems = useStoreData(catalogStore, (store) => store.featuredItems);
+
+  const routeKeys = useMemo(() => Object.keys(routes) as AuthRouteKey[], [routes]);
+
+  const mapToCardRailItems = useCallback(
+    (items: CatalogItem[]): CardRailDisplayItem[] =>
+      items.map(({ routeKey, ...rest }) => ({
+        ...rest,
+        href: routes[routeKey],
+      })),
+    [routes],
+  );
+
+  const previewByCategory = useMemo(
+    () =>
+      categories.map((category) => ({
+        category,
+        items: renderPreviewItems(category.items, mapToCardRailItems),
+      })),
+    [categories, mapToCardRailItems],
+  );
+
   return (
     <AppShell>
-      {/* любой контент справа */}
       <div className="flex h-full min-h-0 flex-col">
-        <div className="flex-1 p-9 overflow-y-auto">
-          <Spacer size={8} />
-          <CardRailOneRow
-            title="Teachers"
-            items={data}
-          />
-          <Spacer size={90} />
-          <CardRailOneRow
-            title="Romantic"
-            items={data}
-          />
-          <Spacer size={90} />
+        <div className="flex-1 overflow-y-auto p-6 md:p-9">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+            <section className="space-y-8">
+              <div>
+                <h1 className="text-2xl font-semibold text-white">Catalog preview</h1>
+                <p className="mt-2 text-sm text-white/60">
+                  Changes you make below update instantly. Use it to experiment with different AI personas and imagery.
+                </p>
+              </div>
+              <CardRailTwoRows
+                title="Landing spotlight"
+                items={renderPreviewItems(featuredItems, mapToCardRailItems)}
+                className="mx-auto max-w-[1400px]"
+              />
+              <div className="space-y-12">
+                {previewByCategory.map(({ category, items }) => (
+                  <CardRailOneRow key={category.id} title={category.title} items={items} />
+                ))}
+              </div>
+            </section>
 
+            <section>
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">Manage your AI cards</h2>
+                  <p className="mt-1 text-sm text-white/60">
+                    Update titles, swap artwork, choose destinations, or remove personas entirely.
+                  </p>
+                </div>
+                <Button variant="outline" onClick={() => catalogStore.addCategory('New category')}>
+                  + Add category
+                </Button>
+              </div>
 
-          <CardRailOneRow
-            title="Story"
-            items={data}
-          />
-          <Spacer size={90} />
+              <div className="mt-8 space-y-8">
+                {categories.map((category) => (
+                  <article
+                    key={category.id}
+                    className="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-xl shadow-black/30 backdrop-blur md:p-8"
+                  >
+                    <header className="flex flex-col gap-4 border-b border-white/5 pb-5 md:flex-row md:items-center md:justify-between">
+                      <div className="w-full md:max-w-sm">
+                        <label className={labelClasses} htmlFor={`category-${category.id}`}>
+                          Category title
+                        </label>
+                        <input
+                          id={`category-${category.id}`}
+                          className={inputClasses}
+                          value={category.title}
+                          onChange={(event) => catalogStore.setCategoryTitle(category.id, event.target.value)}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-3 text-sm text-white/70 md:flex-row md:items-center">
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="radio"
+                            name="featured"
+                            className="size-4 rounded-full border-white/40 bg-black/60 text-violet-500 focus:ring-violet-400"
+                            checked={featuredCategoryId === category.id}
+                            onChange={() => catalogStore.setFeaturedCategory(category.id)}
+                          />
+                          Featured on landing
+                        </label>
+                        <Button
+                          variant="outlineMuted"
+                          onClick={() => catalogStore.removeCategory(category.id)}
+                          disabled={categories.length <= 1}
+                        >
+                          Remove category
+                        </Button>
+                      </div>
+                    </header>
 
-          <CardRailTwoRows title="For fun" items={data} className="mx-auto max-w-[1400px]" />
-          <Spacer size={40} />
+                    <div className="mt-6 space-y-6">
+                      {category.items.map((item) => (
+                        <div
+                          key={item.id}
+                          className="rounded-2xl border border-white/10 bg-black/40 p-5 shadow-lg shadow-black/30 md:p-6"
+                        >
+                          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            <div className="space-y-3">
+                              <div>
+                                <label className={labelClasses} htmlFor={`title-${item.id}`}>
+                                  Title
+                                </label>
+                                <input
+                                  id={`title-${item.id}`}
+                                  className={inputClasses}
+                                  value={item.title}
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, { title: event.target.value })
+                                  }
+                                />
+                              </div>
+                              <div>
+                                <label className={labelClasses} htmlFor={`views-${item.id}`}>
+                                  Views / badge
+                                </label>
+                                <input
+                                  id={`views-${item.id}`}
+                                  className={inputClasses}
+                                  value={item.views ?? ''}
+                                  placeholder="e.g. 1.2K"
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, { views: event.target.value })
+                                  }
+                                />
+                              </div>
+                              <div>
+                                <label className={labelClasses} htmlFor={`route-${item.id}`}>
+                                  Destination route
+                                </label>
+                                <select
+                                  id={`route-${item.id}`}
+                                  className={inputClasses}
+                                  value={item.routeKey}
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, {
+                                      routeKey: event.target.value as AuthRouteKey,
+                                    })
+                                  }
+                                >
+                                  {routeKeys.map((key) => (
+                                    <option key={key} value={key} className="bg-neutral-900 text-white">
+                                      {key}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                            </div>
+
+                            <div className="space-y-3">
+                              <div>
+                                <label className={labelClasses} htmlFor={`image-${item.id}`}>
+                                  Image URL
+                                </label>
+                                <input
+                                  id={`image-${item.id}`}
+                                  className={inputClasses}
+                                  value={item.src}
+                                  placeholder="/img/example.png"
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, { src: event.target.value })
+                                  }
+                                />
+                              </div>
+                              <div>
+                                <label className={labelClasses} htmlFor={`avatar-${item.id}`}>
+                                  Avatar URL (optional)
+                                </label>
+                                <input
+                                  id={`avatar-${item.id}`}
+                                  className={inputClasses}
+                                  value={item.avatarSrc ?? ''}
+                                  placeholder="/img/avatar.png"
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, { avatarSrc: event.target.value })
+                                  }
+                                />
+                              </div>
+                              <div>
+                                <label className={labelClasses} htmlFor={`hover-${item.id}`}>
+                                  Hover text
+                                </label>
+                                <textarea
+                                  id={`hover-${item.id}`}
+                                  className={`${inputClasses} min-h-24 resize-none`}
+                                  value={item.hoverText ?? ''}
+                                  placeholder="Short line that appears on hover"
+                                  onChange={(event) =>
+                                    catalogStore.updateItem(category.id, item.id, { hoverText: event.target.value })
+                                  }
+                                />
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+                            <span className="text-xs text-white/40">ID: {item.id}</span>
+                            <Button
+                              variant="outlineMuted"
+                              onClick={() => catalogStore.removeItem(category.id, item.id)}
+                            >
+                              Remove card
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+
+                      <Button variant="outline" onClick={() => catalogStore.addItem(category.id)}>
+                        + Add AI card
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     </AppShell>
-  )
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,50 +8,13 @@ import CardRailTwoRows from "@/components/ui/CardRailTwoRows";
 import AuthPopup from "@/components/AuthPopup";
 import { Button } from "@/components/ui/Button";
 import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
-import type { AuthRouteKey } from "@/helpers/hooks/useAuthRoutes";
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
 import type { AuthProvider } from "@/stores/AuthStore";
+import type { CatalogItem } from "@/stores/CatalogStore";
 
 // export const metadata = {
 //   title: 'AI Pair — Talk with an AI companion',
 // }
-
-type CardItem = {
-  id: number;
-  cardWidth?: string;
-  src: string;
-  title: string;
-  views: string;
-  hoverText: string;
-  routeKey: AuthRouteKey;
-};
-
-const baseCardData: CardItem[] = [
-  { id: 0, cardWidth: "200", src: '/img/mizuhara.png', title: 'aiAgent α', views: 'New', hoverText: 'Meet the undercover strategist.', routeKey: 'aiAgentProfile' },
-  { id: 1, cardWidth: "200", src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 2, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 3, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 4, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 5, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 6, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 7, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 8, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 9, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 10, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 11, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 12, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 13, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 14, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 15, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 16, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 17, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 18, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 19, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 20, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  { id: 21, src: '/img/mizuhara.png', title: 'Emily', views: '1.2K', hoverText: 'Your little sister...', routeKey: 'chatEmily' },
-  { id: 22, src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg', title: 'Tristan', views: '932', hoverText: 'Sirens — everyone has one...', routeKey: 'chatTristan' },
-  // ...добавляй дальше сколько нужно
-];
 
 // Tailwind is assumed available in the preview. Primary brand color from your prefs: #6f2da8
 // Minimalistic, fast, single-file landing you can paste into a Next.js page or CRA component.
@@ -83,7 +46,7 @@ const GradientBlob = ({ className = "" }: { className?: string }) => (
 
 export default function Landing() {
   const { routes } = useAuthRoutes();
-  const { uiStore, authStore, profileStore } = useRootStore();
+  const { uiStore, authStore, profileStore, catalogStore } = useRootStore();
   const open = useStoreData(uiStore, (store) => store.isAuthPopupOpen);
   const showMobileBanner = useStoreData(uiStore, (store) => store.isMobileBannerVisible);
   const isAuthenticated = useStoreData(authStore, (store) => store.isAuthenticated);
@@ -100,13 +63,15 @@ export default function Landing() {
     });
     uiStore.closeAuthPopup();
   };
+  const featuredItems = useStoreData(catalogStore, (store) => store.featuredItems);
+
   const cardItems = useMemo(
     () =>
-      baseCardData.map(({ routeKey, ...rest }) => ({
-        ...rest,
-        href: routes[routeKey],
+      featuredItems.map((item: CatalogItem) => ({
+        ...item,
+        href: routes[item.routeKey],
       })),
-    [routes],
+    [featuredItems, routes],
   );
 
   return (

--- a/src/stores/CatalogStore.ts
+++ b/src/stores/CatalogStore.ts
@@ -1,0 +1,266 @@
+import { makeAutoObservable } from 'mobx';
+import { BaseStore } from './BaseStore';
+import type { RootStore } from './RootStore';
+import type { AuthRouteKey } from '@/helpers/hooks/useAuthRoutes';
+
+export type CatalogItem = {
+  id: string;
+  title: string;
+  src: string;
+  avatarSrc?: string;
+  views?: string;
+  hoverText?: string;
+  routeKey: AuthRouteKey;
+  cardWidth?: string;
+};
+
+export type CatalogCategory = {
+  id: string;
+  title: string;
+  items: CatalogItem[];
+};
+
+const initialCategories: CatalogCategory[] = [
+  {
+    id: 'teachers',
+    title: 'Teachers',
+    items: [
+      {
+        id: 'teachers-1',
+        cardWidth: '200',
+        src: '/img/mizuhara.png',
+        title: 'aiAgent α',
+        views: 'Profile',
+        hoverText: 'View the creator dossier.',
+        routeKey: 'aiAgentProfile',
+      },
+      {
+        id: 'teachers-2',
+        src: '/img/mizuhara.png',
+        title: 'Emily',
+        views: '1.2K',
+        hoverText: 'Your little sister... Always on your side.',
+        routeKey: 'chatEmily',
+      },
+      {
+        id: 'teachers-3',
+        src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg',
+        title: 'Tristan',
+        views: '932',
+        hoverText: 'Sirens — everyone has one story to tell.',
+        routeKey: 'chatTristan',
+      },
+    ],
+  },
+  {
+    id: 'romantic',
+    title: 'Romantic',
+    items: [
+      {
+        id: 'romantic-1',
+        src: '/img/mizuhara.png',
+        title: 'Celeste',
+        views: '726',
+        hoverText: 'Soft-spoken poet with galaxies in her pocket.',
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'romantic-2',
+        src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg',
+        title: 'Iris',
+        views: '1.1K',
+        hoverText: 'Wandering botanist who sends you pressed flowers.',
+        routeKey: 'adminChat',
+      },
+    ],
+  },
+  {
+    id: 'story',
+    title: 'Story',
+    items: [
+      {
+        id: 'story-1',
+        src: '/img/mizuhara.png',
+        title: 'Ginger',
+        views: '539',
+        hoverText: 'Street photographer who only shoots at night.',
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'story-2',
+        src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg',
+        title: 'Sabine',
+        views: '847',
+        hoverText: 'Runaway heiress looking for a partner in crime.',
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'story-3',
+        src: '/img/mizuhara.png',
+        title: 'Peta',
+        views: '412',
+        hoverText: 'Archivist who remembers every story ever told.',
+        routeKey: 'adminChat',
+      },
+    ],
+  },
+  {
+    id: 'fun',
+    title: 'For fun',
+    items: [
+      {
+        id: 'fun-1',
+        src: '/img/mizuhara.png',
+        title: 'Angelina',
+        views: '1.8K',
+        hoverText: "I'll wait for you at the bar. Don't keep me waiting 💋",
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'fun-2',
+        src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg',
+        title: 'Layla',
+        views: '623',
+        hoverText: 'Highway patrol officer with a mischievous streak.',
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'fun-3',
+        src: '/img/mizuhara.png',
+        title: 'Lisa',
+        views: '998',
+        hoverText: "That's not the point. You're not listening to me.",
+        routeKey: 'adminChat',
+      },
+      {
+        id: 'fun-4',
+        src: '/img/mizuhara_chizuru_by_ppxd6049_dgcf97z-fullview.jpg',
+        title: 'Margerett',
+        views: '712',
+        hoverText: "Well I'm not sure if that's a good idea, I have doubts...",
+        routeKey: 'adminChat',
+      },
+    ],
+  },
+];
+
+export class CatalogStore extends BaseStore {
+  private root: RootStore;
+
+  categories: CatalogCategory[] = initialCategories;
+  featuredCategoryId: string = initialCategories[0]?.id ?? 'teachers';
+
+  constructor(root: RootStore) {
+    super();
+    this.root = root;
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get featuredCategory(): CatalogCategory | undefined {
+    return this.categories.find((category) => category.id === this.featuredCategoryId);
+  }
+
+  get featuredItems(): CatalogItem[] {
+    return this.featuredCategory?.items ?? [];
+  }
+
+  private generateId(prefix: string) {
+    return `${prefix}-${Math.random().toString(36).slice(2, 8)}-${Date.now()}`;
+  }
+
+  private cloneCategories() {
+    return this.categories.map((category) => ({
+      ...category,
+      items: category.items.map((item) => ({ ...item })),
+    }));
+  }
+
+  setFeaturedCategory(categoryId: string) {
+    if (this.categories.some((category) => category.id === categoryId)) {
+      this.featuredCategoryId = categoryId;
+      this.notify();
+    }
+  }
+
+  addCategory(title: string) {
+    const id = this.generateId('category');
+    const nextCategories = [
+      ...this.cloneCategories(),
+      {
+        id,
+        title,
+        items: [],
+      },
+    ];
+    this.categories = nextCategories;
+    if (!this.featuredCategoryId) {
+      this.featuredCategoryId = id;
+    }
+    this.notify();
+    return id;
+  }
+
+  removeCategory(categoryId: string) {
+    const nextCategories = this.cloneCategories().filter((category) => category.id !== categoryId);
+    this.categories = nextCategories;
+    if (this.featuredCategoryId === categoryId) {
+      this.featuredCategoryId = nextCategories[0]?.id ?? '';
+    }
+    this.notify();
+  }
+
+  setCategoryTitle(categoryId: string, title: string) {
+    const nextCategories = this.cloneCategories();
+    const target = nextCategories.find((category) => category.id === categoryId);
+    if (!target) return;
+    target.title = title;
+    this.categories = nextCategories;
+    this.notify();
+  }
+
+  addItem(categoryId: string) {
+    const nextCategories = this.cloneCategories();
+    const target = nextCategories.find((category) => category.id === categoryId);
+    if (!target) return;
+
+    const item: CatalogItem = {
+      id: this.generateId('item'),
+      title: 'New AI agent',
+      src: '',
+      hoverText: '',
+      views: '',
+      routeKey: 'placeholder',
+    };
+
+    target.items = [...target.items, item];
+    this.categories = nextCategories;
+    this.notify();
+    return item.id;
+  }
+
+  updateItem(categoryId: string, itemId: string, updates: Partial<CatalogItem>) {
+    const nextCategories = this.cloneCategories();
+    const target = nextCategories.find((category) => category.id === categoryId);
+    if (!target) return;
+    const itemIndex = target.items.findIndex((item) => item.id === itemId);
+    if (itemIndex === -1) return;
+    const updatedItem = { ...target.items[itemIndex], ...updates };
+    target.items = [
+      ...target.items.slice(0, itemIndex),
+      updatedItem,
+      ...target.items.slice(itemIndex + 1),
+    ];
+    this.categories = nextCategories;
+    this.notify();
+  }
+
+  removeItem(categoryId: string, itemId: string) {
+    const nextCategories = this.cloneCategories();
+    const target = nextCategories.find((category) => category.id === categoryId);
+    if (!target) return;
+    target.items = target.items.filter((item) => item.id !== itemId);
+    this.categories = nextCategories;
+    this.notify();
+  }
+}
+

--- a/src/stores/RootStore.ts
+++ b/src/stores/RootStore.ts
@@ -3,6 +3,7 @@ import { ProfileStore } from './ProfileStore';
 import { ChatStore } from './ChatStore';
 import { UiStore } from './UiStore';
 import { AiBotStore } from './AiBotStore';
+import { CatalogStore } from './CatalogStore';
 
 export class RootStore {
   readonly authStore: AuthStore;
@@ -10,6 +11,7 @@ export class RootStore {
   readonly chatStore: ChatStore;
   readonly uiStore: UiStore;
   readonly aiBotStore: AiBotStore;
+  readonly catalogStore: CatalogStore;
 
   constructor() {
     this.authStore = new AuthStore(this);
@@ -17,5 +19,6 @@ export class RootStore {
     this.chatStore = new ChatStore(this);
     this.uiStore = new UiStore(this);
     this.aiBotStore = new AiBotStore(this);
+    this.catalogStore = new CatalogStore(this);
   }
 }


### PR DESCRIPTION
## Summary
- introduce a catalog store to manage AI card categories and featured items
- rebuild the admin catalog page with live previews and controls to add, edit, or remove cards
- source landing page spotlight cards from the catalog store so updates appear instantly

## Testing
- npm run lint *(fails: pre-existing missing dependency and lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f3355ea88333ae86527fca563b50