### PR TITLE
Integrate store-driven chat list on admin chats page

### DIFF
--- a/src/app/admin/chats/page.tsx
+++ b/src/app/admin/chats/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AppShell from "@/components/AppShell";
+import { useEffect } from "react";
 import PageHeader from "@/components/chats/PageHeader";
 import ChatList from "@/components/chats/ChatList";
 import { AuthRouteKey, useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
@@ -8,8 +9,20 @@ import { useRootStore, useStoreData } from "@/stores/StoreProvider";
 
 export default function ChatsPage() {
   const { routes } = useAuthRoutes();
-  const { chatStore } = useRootStore();
-  const threads = useStoreData(chatStore, (store) => store.threads);
+  const { chatStore, authStore } = useRootStore();
+  const chats = useStoreData(chatStore, (store) => store.chats);
+  const isLoadingChats = useStoreData(chatStore, (store) => store.isLoadingChats);
+  const myId = useStoreData(authStore, (store) => store.user?.id ?? "");
+
+  useEffect(() => {
+    void chatStore.fetchChats({ page: 1 });
+  }, [chatStore]);
+
+  const chatHrefBuilder = (chatId: string) => `${routes.adminChat}?chatId=${chatId}`;
+
+  const handleChatSelect = (chatId: string) => {
+    void chatStore.fetchChat(chatId, myId);
+  };
 
   return (
     <AppShell>
@@ -17,9 +30,11 @@ export default function ChatsPage() {
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
           <PageHeader />
           <ChatList
-            threads={threads}
+            chats={chats}
             routeFor={(key: AuthRouteKey) => routes[key]}
-            onSelect={(thread) => chatStore.setActiveThread(thread.id)}
+            onSelect={(chat) => handleChatSelect(chat._id)}
+            isLoading={isLoadingChats}
+            getChatHref={(chat) => chatHrefBuilder(chat._id)}
           />
         </div>
       </div>

--- a/src/components/chats/ChatAvatar.tsx
+++ b/src/components/chats/ChatAvatar.tsx
@@ -1,19 +1,19 @@
 import Image from "next/image";
-import { ChatThread } from "../../helpers/types/chats";
-
 export default function ChatAvatar({
   name,
-  avatar,
+  avatarUrl,
+  avatarAlt,
 }: {
   name: string;
-  avatar?: ChatThread["avatar"];
+  avatarUrl?: string;
+  avatarAlt?: string;
 }) {
-  if (avatar?.src) {
+  if (avatarUrl) {
     return (
       <div className="relative h-12 w-12 overflow-hidden rounded-full border border-white/10">
         <Image
-          src={avatar.src}
-          alt={avatar.alt ?? name}
+          src={avatarUrl}
+          alt={avatarAlt ?? name}
           fill
           sizes="48px"
           className="object-cover"

--- a/src/components/chats/ChatList.tsx
+++ b/src/components/chats/ChatList.tsx
@@ -1,23 +1,74 @@
 import { AuthRouteKey } from "@/helpers/hooks/useAuthRoutes";
-import { ChatThread } from "../../helpers/types/chats";
+import { ReactNode } from "react";
+import { ChatDTO } from "@/helpers/types";
 import ChatListItem from "./ChatListItem";
 
 export default function ChatList({
-  threads,
+  chats,
   routeFor,
   onSelect,
+  isLoading = false,
+  emptyState,
+  getChatHref,
 }: {
-  threads: ChatThread[];
+  chats: ChatDTO[];
   routeFor: (routeKey: AuthRouteKey) => string;
-  onSelect?: (thread: ChatThread) => void;
+  onSelect?: (chat: ChatDTO) => void;
+  isLoading?: boolean;
+  emptyState?: ReactNode;
+  getChatHref?: (chat: ChatDTO) => string;
 }) {
-  return (
-    <div className="rounded-3xl border border-white/5 bg-white/5 p-3 shadow-[0_10px_40px_rgba(0,0,0,0.35)] backdrop-blur">
+  const renderSkeleton = () => (
+    <ul className="divide-y divide-white/5 overflow-hidden rounded-[28px]">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <li key={index} className="flex items-center gap-4 py-4">
+          <div className="h-12 w-12 animate-pulse rounded-full bg-white/10" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-1/2 animate-pulse rounded bg-white/10" />
+            <div className="h-3 w-3/4 animate-pulse rounded bg-white/5" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+
+  const fallbackHref = (chat: ChatDTO) => `${routeFor("adminChat")}?chatId=${chat._id}`;
+
+  const listContent = () => {
+    if (isLoading) {
+      return renderSkeleton();
+    }
+
+    if (!chats.length) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-center text-sm text-white/60">
+          {emptyState ?? (
+            <>
+              <p>No chats yet.</p>
+              <p className="text-xs text-white/40">Start a conversation to see it here.</p>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    return (
       <ul className="divide-y divide-white/5 overflow-hidden rounded-[28px]">
-        {threads.map((t) => (
-          <ChatListItem key={t.id} thread={t} href={routeFor(t.routeKey)} onSelect={onSelect} />
+        {chats.map((chat) => (
+          <ChatListItem
+            key={chat._id}
+            chat={chat}
+            href={getChatHref?.(chat) ?? fallbackHref(chat)}
+            onSelect={onSelect}
+          />
         ))}
       </ul>
+    );
+  };
+
+  return (
+    <div className="rounded-3xl border border-white/5 bg-white/5 p-3 shadow-[0_10px_40px_rgba(0,0,0,0.35)] backdrop-blur">
+      {listContent()}
     </div>
   );
 }

--- a/src/components/chats/ChatListItem.tsx
+++ b/src/components/chats/ChatListItem.tsx
@@ -1,30 +1,47 @@
 import Link from "next/link";
 import ChatAvatar from "./ChatAvatar";
-import { ChatThread } from "../../helpers/types/chats";
+import { ChatDTO } from "@/helpers/types";
+import { getSmartTime } from "@/helpers/utils/date";
 
 export default function ChatListItem({
-  thread,
+  chat,
   href,
   onSelect,
 }: {
-  thread: ChatThread;
+  chat: ChatDTO;
   href: string;
-  onSelect?: (thread: ChatThread) => void;
+  onSelect?: (chat: ChatDTO) => void;
 }) {
+  const chatName = chat.chatName ?? chat.bot?.name ?? "Untitled chat";
+  const lastMessage = chat.latestMessage;
+  const lastMessageContent = lastMessage?.content;
+  const timestamp = chat.latestMessage?.createdAt
+    ? getSmartTime(chat.latestMessage.createdAt)
+    : null;
+  const preview = lastMessageContent?.trim()
+    ? lastMessageContent
+    : lastMessage?.images?.length
+    ? "Sent a photo"
+    : lastMessage?.attachments?.length
+    ? "Sent an attachment"
+    : "No messages yet";
+
   return (
     <li>
       <Link
         href={href}
         className="group flex w-full items-center gap-4 py-2 transition hover:bg-white/10"
-        onClick={() => onSelect?.(thread)}
+        onClick={() => onSelect?.(chat)}
       >
-        <ChatAvatar name={thread.name} avatar={thread.avatar} />
+        <ChatAvatar name={chatName} />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-3">
-            <p className="truncate text-[15px] font-semibold leading-tight">{thread.name}</p>
-            <span className="shrink-0 text-xs font-medium text-white/50">{thread.timestamp}</span>
+            <p className="truncate text-[15px] font-semibold leading-tight">{chatName}</p>
+            {timestamp ? (
+              <span className="shrink-0 text-xs font-medium text-white/50">{timestamp}</span>
+            ) : null}
           </div>
-          <p className="mt-1 line-clamp-2 text-sm text-white/60">{thread.preview}</p>
+          <p className="mt-1 line-clamp-2 text-sm text-white/60">{preview}</p>
         </div>
       </Link>
     </li>


### PR DESCRIPTION
## Summary
- fetch chats from the chat store when the admin chats page loads and hydrate selection handling
- refactor chat list components to render ChatDTO data with loading and empty states
- allow chat avatars to use direct image props while keeping an initials fallback

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d709f383c4833387075f899f6de113