### PR TITLE
Show chat opponent avatar and sender details in admin chat list

### DIFF
--- a/src/app/admin/chats/page.tsx
+++ b/src/app/admin/chats/page.tsx
@@ -35,6 +35,7 @@ export default function ChatsPage() {
             onSelect={(chat) => handleChatSelect(chat._id)}
             isLoading={isLoadingChats}
             getChatHref={(chat) => chatHrefBuilder(chat._id)}
+            currentUserId={myId}
           />
         </div>
       </div>

--- a/src/components/chats/ChatList.tsx
+++ b/src/components/chats/ChatList.tsx
@@ -10,6 +10,7 @@ export default function ChatList({
   isLoading = false,
   emptyState,
   getChatHref,
+  currentUserId,
 }: {
   chats: ChatDTO[];
   routeFor: (routeKey: AuthRouteKey) => string;
@@ -17,6 +18,7 @@ export default function ChatList({
   isLoading?: boolean;
   emptyState?: ReactNode;
   getChatHref?: (chat: ChatDTO) => string;
+  currentUserId: string;
 }) {
   const renderSkeleton = () => (
     <ul className="divide-y divide-white/5 overflow-hidden rounded-[28px]">
@@ -60,6 +62,7 @@ export default function ChatList({
             chat={chat}
             href={getChatHref?.(chat) ?? fallbackHref(chat)}
             onSelect={onSelect}
+            currentUserId={currentUserId}
           />
         ))}
       </ul>

--- a/src/components/chats/ChatListItem.tsx
+++ b/src/components/chats/ChatListItem.tsx
@@ -1,30 +1,67 @@
 import Link from "next/link";
 import ChatAvatar from "./ChatAvatar";
-import { ChatDTO } from "@/helpers/types";
+import { ChatDTO, UserDTO } from "@/helpers/types";
 import { getSmartTime } from "@/helpers/utils/date";
+import { getUserAvatar, getUserFullName } from "@/helpers/utils/user";
 
 export default function ChatListItem({
   chat,
   href,
   onSelect,
+  currentUserId,
 }: {
   chat: ChatDTO;
   href: string;
   onSelect?: (chat: ChatDTO) => void;
+  currentUserId: string;
 }) {
-  const chatName = chat.chatName ?? chat.bot?.name ?? "Untitled chat";
+  type ChatParticipant = Pick<UserDTO, "_id" | "name" | "lastname" | "avatarFile">;
+
+  const rawParticipants = (chat.users as unknown as Array<ChatParticipant | string>) ?? [];
+  const participants = rawParticipants.filter(
+    (user): user is ChatParticipant => typeof user === "object" && user !== null && "_id" in user
+  );
+  const opponent = !chat.isGroupChat
+    ? participants.find((user) => user && user._id !== currentUserId)
+    : undefined;
+
+  const chatName = opponent
+    ? getUserFullName(opponent)
+    : chat.chatName ?? chat.bot?.name ?? "Untitled chat";
   const lastMessage = chat.latestMessage;
   const lastMessageContent = lastMessage?.content;
   const timestamp = chat.latestMessage?.createdAt
     ? getSmartTime(chat.latestMessage.createdAt)
     : null;
-  const preview = lastMessageContent?.trim()
+  const senderId = lastMessage?.sender?._id;
+  const senderUser = senderId
+    ? participants.find((user) => user && user._id === senderId)
+    : undefined;
+  const isMyMessage = senderId === currentUserId;
+  const senderLabel = lastMessage
+    ? isMyMessage
+      ? "Я"
+      : senderUser
+      ? getUserFullName(senderUser)
+      : chat.bot?.name ?? "Собеседник"
+    : "";
+
+  const messageBody = lastMessageContent?.trim()
     ? lastMessageContent
     : lastMessage?.images?.length
-    ? "Sent a photo"
+    ? "Отправлено фото"
     : lastMessage?.attachments?.length
-    ? "Sent an attachment"
-    : "No messages yet";
+    ? "Отправлен файл"
+    : "Нет сообщений";
+
+  const preview = lastMessage
+    ? senderLabel
+      ? `${senderLabel}: ${messageBody}`
+      : messageBody
+    : messageBody;
+
+  const avatarUrl = opponent ? getUserAvatar(opponent) : undefined;
+  const avatarAlt = opponent ? getUserFullName(opponent) : chatName;
 
   return (
     <li>
@@ -33,7 +70,7 @@ export default function ChatListItem({
         className="group flex w-full items-center gap-4 py-2 transition hover:bg-white/10"
         onClick={() => onSelect?.(chat)}
       >
-        <ChatAvatar name={chatName} />
+        <ChatAvatar name={chatName} avatarUrl={avatarUrl} avatarAlt={avatarAlt} />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-3">
             <p className="truncate text-[15px] font-semibold leading-tight">{chatName}</p>


### PR DESCRIPTION
## Summary
- pass the current user id into the admin chat list so list items can identify the active user
- render the private chat opponent's full name and avatar in the list entry
- prepend the last message preview with the sender label, showing "Я" for the current user

## Testing
- npm run lint *(fails: pre-existing lint rule violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d710b5db448333b7d8cdfecf292b4c