### PR TITLE
Implement chat page messaging features

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,47 +1,84 @@
 'use client';
 
+import type { MessageDTO } from '@/helpers/types';
+import { useMemo } from 'react';
 
-import React from 'react';
-import type { ChatMessage } from './types';
+type MessageBubbleProps = {
+  message: MessageDTO;
+  isOwn: boolean;
+  isPinned: boolean;
+  senderName: string;
+  onPin: (message: MessageDTO) => void;
+  onUnpin: (messageId: string) => void;
+};
 
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
 
-export default function MessageBubble({ m }: { m: ChatMessage }) {
-    const isRight = m.align === 'right';
-    return (
-        <article className={`flex ${isRight ? 'justify-end' : 'justify-start'}`}>
-            <div
-                className={
-                    'relative max-w-[80%] rounded-3xl border border-white/10 p-5 shadow-2xl backdrop-blur transition ' +
-                    (isRight
-                        ? 'bg-gradient-to-br from-amber-300/90 to-orange-500/90 text-neutral-900'
-                        : 'bg-white/5 text-white')
-                }
-            >
-                <div
-                    className={
-                        'absolute top-4 flex h-10 w-10 items-center justify-center rounded-2xl text-xs font-semibold shadow-lg backdrop-blur ' +
-                        (isRight ? '-right-5 bg-white text-neutral-900' : '-left-5 bg-white/10 text-white/70')
-                    }
-                >
-                    {m.timestamp}
-                </div>
-                <div
-                    className={
-                        'flex items-center justify-between text-xs uppercase tracking-wide ' +
-                        (isRight ? 'text-neutral-900/70' : 'text-white/60')
-                    }
-                >
-                    <span className={'font-semibold ' + (isRight ? 'text-neutral-900' : 'text-white/80')}>{m.speaker}</span>
-                    <span>{isRight ? 'Now' : 'Scene'}</span>
-                </div>
-                <div className="mt-3 space-y-3 text-sm">
-                    {m.content.split('\n').map((line, idx) => (
-                        <p key={idx} className={'leading-relaxed ' + (isRight ? 'text-neutral-900' : 'text-white/90')}>
-                            {line}
-                        </p>
-                    ))}
-                </div>
-            </div>
-        </article>
-    );
+export default function MessageBubble({ message, isOwn, isPinned, senderName, onPin, onUnpin }: MessageBubbleProps) {
+  const timestamp = useMemo(() => formatTimestamp(message.createdAt), [message.createdAt]);
+  const content = typeof message.content === 'string' ? message.content : '';
+  const displayName = isOwn ? 'You' : senderName || 'Anonymous';
+
+  return (
+    <article className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={
+          'group relative max-w-[82%] rounded-3xl border border-white/10 px-5 py-4 shadow-2xl backdrop-blur transition ' +
+          (isOwn
+            ? 'bg-gradient-to-br from-amber-300/90 to-orange-500/90 text-neutral-900'
+            : 'bg-white/5 text-white')
+        }
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-1 flex-col">
+            <span className={`text-xs font-semibold uppercase tracking-wide ${isOwn ? 'text-neutral-900' : 'text-white/70'}`}>
+              {displayName}
+            </span>
+            {timestamp ? (
+              <span className={`text-[11px] ${isOwn ? 'text-neutral-900/80' : 'text-white/60'}`}>{timestamp}</span>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={() => (isPinned ? onUnpin(message._id) : onPin(message))}
+            className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${
+              isPinned
+                ? isOwn
+                  ? 'border-neutral-900/50 bg-neutral-900/20 text-neutral-900'
+                  : 'border-white/50 bg-white/10 text-white'
+                : isOwn
+                  ? 'border-transparent bg-neutral-900/80 text-white hover:bg-neutral-900'
+                  : 'border-white/20 bg-white/10 text-white/80 hover:border-white/40 hover:text-white'
+            }`}
+          >
+            {isPinned ? 'Unpin' : 'Pin'}
+          </button>
+        </div>
+
+        <div className="mt-3 space-y-2 text-sm leading-relaxed">
+          {content.split('\n').map((line, index) => (
+            <p key={index} className={isOwn ? 'text-neutral-900' : 'text-white/90'}>
+              {line}
+            </p>
+          ))}
+        </div>
+
+        {isPinned ? (
+          <div
+            className={`mt-3 inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${
+              isOwn ? 'bg-neutral-900/10 text-neutral-900' : 'bg-white/10 text-white/80'
+            }`}
+          >
+            Pinned
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
 }

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,17 +1,38 @@
 'use client';
 
-
-import React from 'react';
-import type { ChatMessage } from './types';
+import type { MessageDTO } from '@/helpers/types';
 import MessageBubble from './MessageBubble';
 
+type MessageListProps = {
+  messages: MessageDTO[];
+  currentUserId: string;
+  isMessagePinned: (id: string) => boolean;
+  onPinMessage: (message: MessageDTO) => void;
+  onUnpinMessage: (messageId: string) => void;
+  resolveSenderName: (message: MessageDTO) => string;
+};
 
-export default function MessageList({ messages }: { messages: ChatMessage[] }) {
-    return (
-        <div className="space-y-6">
-            {messages.map((m) => (
-                <MessageBubble key={m.id} m={m} />
-            ))}
-        </div>
-    );
+export default function MessageList({
+  messages,
+  currentUserId,
+  isMessagePinned,
+  onPinMessage,
+  onUnpinMessage,
+  resolveSenderName,
+}: MessageListProps) {
+  return (
+    <div className="space-y-4">
+      {messages.map((message) => (
+        <MessageBubble
+          key={message._id}
+          message={message}
+          isOwn={message.sender?._id === currentUserId}
+          isPinned={isMessagePinned(message._id)}
+          senderName={resolveSenderName(message)}
+          onPin={onPinMessage}
+          onUnpin={onUnpinMessage}
+        />
+      ))}
+    </div>
+  );
 }

--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -88,6 +88,12 @@ export class ChatStore extends BaseStore {
     }
   }
 
+  clearPinnedMessages() {
+    runInAction(() => {
+      this.pinnedMessages = [];
+    });
+  }
+
   isMessagePinned(id: string) {
     return this.pinnedMessages?.some((m) => m._id === id);
   }


### PR DESCRIPTION
## Summary
- wire the admin chat page to the chat store so it loads conversations, pinned messages, and chat metadata
- enable sending, pinning, and unpinning messages with updated chat UI components
- add a store helper for clearing pinned messages when switching conversations

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d713799c34833396fa6de28d02d3a8