### PR TITLE
Show newly sent chat messages immediately

### DIFF
--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -285,19 +285,15 @@ export class ChatStore extends BaseStore {
       );
 
       const messageData = {
-        _id: data.data._id,
-        sender: data.data.sender,
-        content: data.data.content,
-        chat: data.data.chat,
-        createdAt: data.data.createdAt,
-        // ...(!_.isEmpty(data.data.replyTo) && { replyTo: data.data.replyTo }),
-        ...(data.data.images && { images: data.data.images }),
-        ...(data.data.attachments && { attachments: data.data.attachments }),
-      };
+        ...data.data,
+        readBy: data.data.readBy ?? [],
+        isEdited: data.data.isEdited ?? false,
+      } as MessageDTO;
 
       runInAction(() => {
-        this.messages.push(messageData as any);
+        this.messages.push(messageData);
       });
+      this.notify();
     } catch (err) {
       // uiStore.showSnackbar("Failed", "error");
       console.error("Ошибка при отправке сообщения:", err);


### PR DESCRIPTION
## Summary
- reuse the backend response to build a complete message payload when sending
- notify the chat store after enqueueing a new message so the UI updates instantly

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d71931c2bc8333a909ac756cf9d05f