### PR TITLE
Fix chat avatar loading after page refresh

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -111,7 +111,7 @@ export default function ChatPage() {
   }, [chatId, chatStore]);
 
   useEffect(() => {
-    if (!chatId || !myId) return;
+    if (!chatId) return;
     void chatStore.fetchChat(chatId, myId);
   }, [chatId, chatStore, myId]);
 

--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -215,9 +215,10 @@ export class ChatStore extends BaseStore {
       runInAction(() => {
         this.selectedChat = response.data;
         if (!response.data.isGroupChat) {
-          this.opponentId = response.data?.users?.find(user => user._id !== myId)?._id
-        }
-        else {
+          if (myId) {
+            this.opponentId = response.data?.users?.find(user => user._id !== myId)?._id;
+          }
+        } else {
           this.opponentId = undefined
         }
       });


### PR DESCRIPTION
## Summary
- fetch chat metadata on refresh even before the current user id resolves so avatar data is available immediately
- avoid overriding the stored opponent id until the viewer id is known

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7248f9ce08333b0efa48f04f74789