### PR TITLE
Refine chat profile linking for ai bot role

### DIFF
--- a/src/services/chat/ChatResponse.ts
+++ b/src/services/chat/ChatResponse.ts
@@ -12,7 +12,7 @@ export interface ChatById {
 }
 
 export type ReadedMessageResponse = {
-  senderId: string,
-  chatId: string,
-  lastReadedMessageId: string,
-}
+  senderId: string;
+  chatId: string;
+  lastReadedMessageId: string;
+};


### PR DESCRIPTION
## Summary
- link the chat header to either the AI agent profile or user profile based on the opponent's role
- remove the previously added bot-specific fields from the chat response type

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d782679acc8333ae9de9e0199035ce