### PR TITLE
Implement consistent back navigation across profile pages

### DIFF
--- a/src/app/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -121,24 +121,25 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
         )}
 
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-4 pb-32 md:pb-20 pt-4 md:pt-14">
-          {canEdit && (
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  onClick={() => router.back()}
-                  variant="frostedIcon"
-                  aria-label="Go back"
-                >
-                  <ArrowLeft className="size-5" />
-                </Button>
-                <Button type="button" variant="frostedIcon" aria-label="Share agent">
-                  <Share2 className="size-5" />
-                </Button>
-                <Button type="button" variant="frostedIcon" aria-label="More options">
-                  <MoreHorizontal className="size-5" />
-                </Button>
-              </div>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                onClick={() => router.back()}
+                variant="frostedIcon"
+                className="hidden md:inline-flex"
+                aria-label="Go back"
+              >
+                <ArrowLeft className="size-5" />
+              </Button>
+              <Button type="button" variant="frostedIcon" aria-label="Share agent">
+                <Share2 className="size-5" />
+              </Button>
+              <Button type="button" variant="frostedIcon" aria-label="More options">
+                <MoreHorizontal className="size-5" />
+              </Button>
+            </div>
+            {canEdit && (
               <div className="flex items-center gap-3">
                 <Button
                   type="button"
@@ -148,8 +149,8 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
                   Edit AI Agent
                 </Button>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {!aiBot ? (
             <div className="rounded-3xl border border-white/10 bg-neutral-900/70 p-8 text-center text-sm text-white/70">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/Button';
 import {
@@ -33,6 +34,7 @@ export default function AppShell({
     sidebarWidth = 280,
     sidebarCollapsed = 80,
 }: AppShellProps) {
+    const router = useRouter();
     const { routes } = useAuthRoutes();
 
     const { uiStore, profileStore, authStore, chatStore } = useRootStore();
@@ -191,11 +193,11 @@ export default function AppShell({
                 {/* верхняя панель с кнопкой открытия */}
                 <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b border-white/10 bg-neutral-900/90 px-3 py-3 backdrop-blur">
                     <Button
-                        onClick={() => uiStore.openMobileSidebar()}
+                        onClick={() => router.back()}
                         variant="sidebarIcon"
-                        aria-label="Open menu"
+                        aria-label="Go back"
                     >
-                        <Menu />
+                        <ChevronLeft />
                     </Button>
                     <div className="flex-1">
                         <label className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2">

--- a/src/components/profile/HeaderActions.tsx
+++ b/src/components/profile/HeaderActions.tsx
@@ -1,12 +1,22 @@
-import { ArrowLeft, MoreHorizontal, Share2, Sparkles } from "lucide-react";
+"use client";
+
+import { ArrowLeft, MoreHorizontal, Share2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { Button } from '@/components/ui/Button';
 
 
 export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
+    const router = useRouter();
     return (
         <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-2">
-                <Button variant="frostedIcon">
+                <Button
+                    type="button"
+                    onClick={() => router.back()}
+                    variant="frostedIcon"
+                    className="hidden md:inline-flex"
+                    aria-label="Go back"
+                >
                     <ArrowLeft className="size-5" />
                 </Button>
                 <Button variant="frostedIcon">

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { ArrowLeft, Check, MoreHorizontal, Share2, Sparkles } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
 
@@ -23,11 +26,18 @@ export default function HeaderBar({
       : "Subscribe";
   const ButtonIcon = isFollowing ? Check : Sparkles;
   const buttonVariant = isFollowing ? "frostedPill" : "subscribe";
+  const router = useRouter();
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-4">
       <div className="flex items-center gap-2">
-        <Button variant="frostedIcon">
+        <Button
+          type="button"
+          onClick={() => router.back()}
+          variant="frostedIcon"
+          className="hidden md:inline-flex"
+          aria-label="Go back"
+        >
           <ArrowLeft className="size-5" />
         </Button>
         <Button variant="frostedIcon">


### PR DESCRIPTION
## Summary
- replace the mobile AppShell header menu trigger with a router-powered back button
- hook profile and user header back buttons up to router.back while keeping them desktop-only
- show the agent profile header actions (including back) for all viewers and reuse router.back

## Testing
- npm run lint *(fails: pre-existing lint/type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d794e1ca6c8333ae62354b2c24bb58