### PR TITLE
Show auth popup from app shell

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { useAuthRoutes } from '@/helpers/hooks/useAuthRoutes';
 import ProfileSection from './ProfileSection';
+import AuthPopupContainer from './AuthPopupContainer';
 import { useRootStore, useStoreData } from '@/stores/StoreProvider';
 import { getUserAvatar, getUserFullName } from '@/helpers/utils/user';
 import { textRefactor } from '@/helpers/utils/common';
@@ -311,6 +312,7 @@ export default function AppShell({
                     <MessageSquare className="size-6" />
                 </Link>
             </nav>
+            <AuthPopupContainer />
         </div>
     );
 }

--- a/src/components/AuthPopupContainer.tsx
+++ b/src/components/AuthPopupContainer.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback } from 'react';
+import AuthPopup from './AuthPopup';
+import { useRootStore, useStoreData } from '@/stores/StoreProvider';
+import type { AuthProvider } from '@/stores/AuthStore';
+
+export default function AuthPopupContainer() {
+  const { uiStore, authStore, profileStore } = useRootStore();
+  const isOpen = useStoreData(uiStore, (store) => store.isAuthPopupOpen);
+  const profileName = useStoreData(profileStore, (store) => store.profile.userName || '');
+
+  const handleProviderAuth = useCallback(
+    (provider: AuthProvider) => {
+      authStore.startAuth(provider);
+      const normalized = profileName.trim().toLowerCase().replace(/\s+/g, '.');
+      const fallbackName = profileName.trim() || 'User';
+
+      authStore.completeAuth({
+        id: `${provider}-${Date.now()}`,
+        name: fallbackName,
+        email: `${normalized || 'user'}@example.com`,
+      });
+      uiStore.closeAuthPopup();
+    },
+    [authStore, profileName, uiStore],
+  );
+
+  return (
+    <AuthPopup
+      open={isOpen}
+      onClose={() => uiStore.closeAuthPopup()}
+      onGoogle={() => handleProviderAuth('google')}
+      onApple={() => handleProviderAuth('apple')}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add an AuthPopupContainer component that wires stores to the shared auth popup
- mount the container inside AppShell so the login popup appears outside the landing page

## Testing
- npm run lint *(fails: pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ab50c30083339a0b573238197029