### PR TITLE
refactor: source admin bots from store

### DIFF
--- a/src/helpers/types/dtos/AiBotMainPageDto.ts
+++ b/src/helpers/types/dtos/AiBotMainPageDto.ts
@@ -1,0 +1,20 @@
+export interface AiBotMainPageDetails {
+  categories?: string[];
+  intro?: string;
+  usefulness?: string[];
+  photos?: string[];
+}
+
+export interface AiBotMainPageBot {
+  id: string;
+  name?: string;
+  lastname?: string;
+  avatarFile?: string;
+  profession?: string;
+  userBio?: string;
+  username?: string;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  details: AiBotMainPageDetails;
+}

--- a/src/helpers/types/dtos/index.ts
+++ b/src/helpers/types/dtos/index.ts
@@ -1,3 +1,5 @@
 export * from "./ChatDto";
 export * from "./MessageDto";
 export * from "./UserDto";
+export * from "./AiBotDto";
+export * from "./AiBotMainPageDto";

--- a/src/services/ai-bot-details/AiBotDetailsService.ts
+++ b/src/services/ai-bot-details/AiBotDetailsService.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse } from "axios";
+
+import $api from "@/helpers/http";
+import { AiBotMainPageBot } from "@/helpers/types";
+
+class AiBotDetailsService {
+  public async fetchAiBotsForMainPage(): Promise<AxiosResponse<AiBotMainPageBot[]>> {
+    return $api.get("/ai-bot-details/fetchAiBotsForMainPage");
+  }
+}
+
+const aiBotDetailsService = new AiBotDetailsService();
+
+export default aiBotDetailsService;


### PR DESCRIPTION
## Summary
- move the main-page AI bot fetch into `AiBotStore` with shared loading/error state
- update the admin landing page to read bots from the store instead of fetching locally
- continue grouping bots by category while relying on the centralized store data

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c68e03988333a215d70cd73382ab