### PR TITLE
Start AI agent chats via message creation

### DIFF
--- a/src/components/ai-agent/ActionButtons.tsx
+++ b/src/components/ai-agent/ActionButtons.tsx
@@ -31,6 +31,8 @@ interface PrimaryCTAProps {
   isBusy?: boolean;
   disableFollowAction?: boolean;
   onToggleFollow?: () => void;
+  onStartChat?: () => void | Promise<void>;
+  isChatLoading?: boolean;
 }
 
 export function PrimaryCTAs({
@@ -39,6 +41,8 @@ export function PrimaryCTAs({
   isBusy,
   disableFollowAction,
   onToggleFollow,
+  onStartChat,
+  isChatLoading,
 }: PrimaryCTAProps) {
   const isActionDisabled = disableFollowAction || isBusy || !onToggleFollow;
   const buttonLabel = isBusy
@@ -48,6 +52,7 @@ export function PrimaryCTAs({
       : "Follow";
   const ButtonIcon = isFollowing ? Check : UserPlus;
   const buttonVariant = isFollowing ? "outline" : "primary";
+  const chatButtonLabel = isChatLoading ? "Opening chat..." : "Chat with aiAgent";
 
   return (
     <div className="flex flex-col gap-3 md:flex-row">
@@ -63,12 +68,25 @@ export function PrimaryCTAs({
           {buttonLabel}
         </Button>
       </div>
-      <Link
-        href={chatHref}
-        className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5"
-      >
-        <MessageCircle className="size-4" /> Chat with aiAgent
-      </Link>
+      {onStartChat ? (
+        <Button
+          type="button"
+          variant="outline"
+          className="flex flex-1 items-center justify-center gap-2"
+          onClick={onStartChat}
+          disabled={isChatLoading}
+        >
+          <MessageCircle className="size-4" />
+          {chatButtonLabel}
+        </Button>
+      ) : (
+        <Link
+          href={chatHref}
+          className="flex flex-1 items-center justify-center gap-2 rounded-2xl border border-white/15 px-4 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/5"
+        >
+          <MessageCircle className="size-4" /> Chat with aiAgent
+        </Link>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wire the AI agent profile CTA to create or fetch the chat thread through `messageById`
- redirect to the chat page once the thread id is available and show a loading state during navigation
- allow PrimaryCTAs to call a callback for opening chats instead of always linking directly

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d839aee8708333bf115c0b309e4352