### PR TITLE
Enforce auth popup when unauthenticated on inner pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { StoreProvider } from "@/stores/StoreProvider";
+import AuthPromptManager from "@/components/AuthPromptManager";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +27,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <StoreProvider>{children}</StoreProvider>
+        <StoreProvider>
+          <AuthPromptManager />
+          {children}
+        </StoreProvider>
       </body>
     </html>
   );

--- a/src/components/AuthPromptManager.tsx
+++ b/src/components/AuthPromptManager.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { useRootStore, useStoreData } from '@/stores/StoreProvider';
+
+const LANDING_PATH = '/';
+
+export default function AuthPromptManager() {
+  const pathname = usePathname();
+  const { authStore, uiStore } = useRootStore();
+  const isAuthenticated = useStoreData(authStore, (store) => store.isAuthenticated);
+  const isPopupOpen = useStoreData(uiStore, (store) => store.isAuthPopupOpen);
+  const wasForcedRef = useRef(false);
+
+  const shouldForceAuthPopup = !isAuthenticated && pathname !== LANDING_PATH;
+
+  useEffect(() => {
+    if (shouldForceAuthPopup) {
+      if (!isPopupOpen) {
+        wasForcedRef.current = true;
+        uiStore.openAuthPopup();
+      }
+      return;
+    }
+
+    if (wasForcedRef.current) {
+      wasForcedRef.current = false;
+      if (isPopupOpen) {
+        uiStore.closeAuthPopup();
+      }
+    }
+  }, [shouldForceAuthPopup, isPopupOpen, uiStore]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a client-side auth prompt manager that forces the auth popup to appear when an unauthenticated user navigates away from the landing page
- hook the prompt manager into the root layout so it runs on every route while respecting the landing page exception

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d83a3c4e0c83339391388cd0114694