### PR TITLE
Improve admin auth gating and add logout menu

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, MoreHorizontal, Share2 } from "lucide-react";
+import { ArrowLeft, Share2 } from "lucide-react";
 
 import AppShell from "@/components/AppShell";
 import GradientBackdrop from "@/components/ai-agent/GradientBackdrop";
@@ -15,6 +15,7 @@ import HighlightsSidebar from "@/components/ai-agent/HighlightsSidebar";
 import BotGallery from "@/components/ai-agent/BotGallery";
 import { Button } from "@/components/ui/Button";
 import EditAiAgentDialog from "@/components/ai-agent/edit/EditAiAgentDialog";
+import MoreActionsMenu from "@/components/MoreActionsMenu";
 
 import { useAuthRoutes } from "@/helpers/hooks/useAuthRoutes";
 import { getUserFullName } from "@/helpers/utils/user";
@@ -159,9 +160,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
               <Button type="button" variant="frostedIcon" aria-label="Share agent">
                 <Share2 className="size-5" />
               </Button>
-              <Button type="button" variant="frostedIcon" aria-label="More options">
-                <MoreHorizontal className="size-5" />
-              </Button>
+              <MoreActionsMenu />
             </div>
             {canEdit && (
               <div className="flex items-center gap-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,7 +87,7 @@ const GradientBlob = ({ className = "" }: { className?: string }) => (
 );
 
 export default function Landing() {
-  const { routes } = useAuthRoutes();
+  const { routes, goToAdmin } = useAuthRoutes();
   const { uiStore, authStore, profileStore, aiBotStore } = useRootStore();
   const open = useStoreData(uiStore, (store) => store.isAuthPopupOpen);
   const showMobileBanner = useStoreData(uiStore, (store) => store.isMobileBannerVisible);
@@ -104,13 +104,22 @@ export default function Landing() {
 
   const handleAuth = (provider: AuthProvider) => {
     authStore.startAuth(provider);
-    const normalized = profileName.toLowerCase().replace(/\s+/g, '.');
+    const rawProfileName = profileName ?? '';
+    const normalizedProfile = rawProfileName.trim().toLowerCase().replace(/\s+/g, '.');
+    const fallbackName = rawProfileName.trim() || 'User';
     authStore.completeAuth({
       id: `${provider}-${Date.now()}`,
-      name: profileName,
-      email: `${normalized || 'user'}@example.com`,
+      name: fallbackName,
+      email: `${normalizedProfile || 'user'}@example.com`,
     });
     uiStore.closeAuthPopup();
+  };
+  const handleAccountClick = () => {
+    if (isAuthenticated) {
+      goToAdmin();
+      return;
+    }
+    uiStore.openAuthPopup();
   };
   const cardItems: LandingCardItem[] = useMemo(() => {
     if (mainPageBots.length > 0) {
@@ -149,7 +158,7 @@ export default function Landing() {
           </div>
           <div className="flex items-center gap-3">
             <div className="hidden md:inline">
-              <Button onClick={() => uiStore.openAuthPopup()} variant="ghostRounded">
+              <Button onClick={handleAccountClick} variant="ghostRounded">
                 {isAuthenticated ? authUser?.name ?? profileName : 'Sign in'}
               </Button>
             </div>

--- a/src/components/AuthPromptManager.tsx
+++ b/src/components/AuthPromptManager.tsx
@@ -4,16 +4,17 @@ import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import { useRootStore, useStoreData } from '@/stores/StoreProvider';
 
-const LANDING_PATH = '/';
-
 export default function AuthPromptManager() {
   const pathname = usePathname();
   const { authStore, uiStore } = useRootStore();
   const isAuthenticated = useStoreData(authStore, (store) => store.isAuthenticated);
+  const hasAttemptedAutoLogin = useStoreData(authStore, (store) => store.hasAttemptedAutoLogin);
   const isPopupOpen = useStoreData(uiStore, (store) => store.isAuthPopupOpen);
   const wasForcedRef = useRef(false);
 
-  const shouldForceAuthPopup = !isAuthenticated && pathname !== LANDING_PATH;
+  const isProtectedRoute = pathname?.startsWith('/admin') ?? false;
+  const shouldForceAuthPopup =
+    hasAttemptedAutoLogin && isProtectedRoute && !isAuthenticated;
 
   useEffect(() => {
     if (shouldForceAuthPopup) {

--- a/src/components/MoreActionsMenu.tsx
+++ b/src/components/MoreActionsMenu.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { LogOut, MoreHorizontal } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Button, type ButtonVariant } from '@/components/ui/Button';
+import { useRootStore, useStoreData } from '@/stores/StoreProvider';
+import { useAuthRoutes } from '@/helpers/hooks/useAuthRoutes';
+
+interface MoreActionsMenuProps {
+  buttonAriaLabel?: string;
+  align?: 'start' | 'end';
+  buttonVariant?: ButtonVariant;
+  className?: string;
+}
+
+export default function MoreActionsMenu({
+  buttonAriaLabel = 'More options',
+  align = 'end',
+  buttonVariant = 'frostedIcon',
+  className,
+}: MoreActionsMenuProps) {
+  const { authStore } = useRootStore();
+  const hasAttemptedAutoLogin = useStoreData(authStore, (store) => store.hasAttemptedAutoLogin);
+  const [open, setOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { goTo } = useAuthRoutes();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!hasAttemptedAutoLogin) {
+      setOpen(false);
+    }
+  }, [hasAttemptedAutoLogin]);
+
+  const handleLogout = async () => {
+    if (isLoggingOut) return;
+    setIsLoggingOut(true);
+    try {
+      setOpen(false);
+      await authStore.logout();
+      goTo('home');
+    } catch (error) {
+      console.error('Failed to logout', error);
+      router.refresh();
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className={`relative ${className ?? ''}`}>
+      <Button
+        type="button"
+        variant={buttonVariant}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={buttonAriaLabel}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <MoreHorizontal className="size-5" />
+      </Button>
+      {open && (
+        <div
+          className={`absolute z-50 mt-2 w-44 rounded-xl border border-white/10 bg-neutral-900/95 p-1 text-sm text-white/90 shadow-xl backdrop-blur ${align === 'end' ? 'right-0' : 'left-0'}`}
+          role="menu"
+        >
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition hover:bg-white/10"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+          >
+            <LogOut className="size-4" />
+            {isLoggingOut ? 'Logging out…' : 'Log out'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/HeaderActions.tsx
+++ b/src/components/profile/HeaderActions.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ArrowLeft, MoreHorizontal, Share2 } from "lucide-react";
+import { ArrowLeft, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from '@/components/ui/Button';
 import { useBreakpoint } from "@/helpers/hooks/useBreakpoint";
+import MoreActionsMenu from "@/components/MoreActionsMenu";
 
 
 export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
@@ -26,9 +27,7 @@ export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
                 <Button variant="frostedIcon">
                     <Share2 className="size-5" />
                 </Button>
-                <Button variant="frostedIcon">
-                    <MoreHorizontal className="size-5" />
-                </Button>
+                <MoreActionsMenu />
             </div>
             <div className="flex items-center gap-3">
                 <Button onClick={onEdit} variant="solidWhitePill">

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { ArrowLeft, Check, MoreHorizontal, Share2, Sparkles } from "lucide-react";
+import { ArrowLeft, Check, Share2, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
 import { useBreakpoint } from "@/helpers/hooks/useBreakpoint";
+import MoreActionsMenu from "@/components/MoreActionsMenu";
 
 interface HeaderBarProps {
   isFollowing?: boolean;
@@ -46,9 +47,7 @@ export default function HeaderBar({
         <Button variant="frostedIcon">
           <Share2 className="size-5" />
         </Button>
-        <Button variant="frostedIcon">
-          <MoreHorizontal className="size-5" />
-        </Button>
+        <MoreActionsMenu />
       </div>
       <Button
         variant={buttonVariant}


### PR DESCRIPTION
## Summary
- track auto-login resolution in the auth store and only render the admin shell once authentication state is known, now preserving the existing shell layout
- gate the admin area behind an authentication overlay that shows a spinner while auto-login is pending and a sign-in prompt afterwards
- adjust the landing account control to route to the admin dashboard when signed in and limit auth popups to protected routes

## Testing
- npm run lint *(fails: pre-existing lint violations in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d908d3c41c833382f8f4c024721564