### PR TITLE
Add reporting modal to profile actions menu

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -160,7 +160,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
               <Button type="button" variant="frostedIcon" aria-label="Share agent">
                 <Share2 className="size-5" />
               </Button>
-              <MoreActionsMenu />
+              <MoreActionsMenu mode="aiAgent" reportTargetId={aiBotProfileId} />
             </div>
             {canEdit && (
               <div className="flex items-center gap-3">

--- a/src/app/admin/profile/user/[id]/ClientUserProfilePage.tsx
+++ b/src/app/admin/profile/user/[id]/ClientUserProfilePage.tsx
@@ -88,6 +88,8 @@ export default function UserProfilePage({ profileId }: UserProfilePageProps) {
               isBusy={isUpdatingFollow}
               onToggleFollow={handleToggleFollow}
               disableFollowAction={!profileUserId}
+              isCurrentUser={isViewingOwnProfile}
+              profileId={profileUserId}
             />
             <ProfileCard
               profile={profile}

--- a/src/components/MoreActionsMenu.tsx
+++ b/src/components/MoreActionsMenu.tsx
@@ -1,17 +1,20 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { LogOut, MoreHorizontal } from 'lucide-react';
+import { Flag, LogOut, MoreHorizontal } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Button, type ButtonVariant } from '@/components/ui/Button';
 import { useRootStore, useStoreData } from '@/stores/StoreProvider';
 import { useAuthRoutes } from '@/helpers/hooks/useAuthRoutes';
+import ReportModal from '@/components/ReportModal';
 
 interface MoreActionsMenuProps {
   buttonAriaLabel?: string;
   align?: 'start' | 'end';
   buttonVariant?: ButtonVariant;
   className?: string;
+  mode?: 'self' | 'user' | 'aiAgent';
+  reportTargetId?: string;
 }
 
 export default function MoreActionsMenu({
@@ -19,11 +22,16 @@ export default function MoreActionsMenu({
   align = 'end',
   buttonVariant = 'frostedIcon',
   className,
+  mode = 'self',
+  reportTargetId,
 }: MoreActionsMenuProps) {
-  const { authStore } = useRootStore();
+  const { authStore, profileStore, uiStore } = useRootStore();
   const hasAttemptedAutoLogin = useStoreData(authStore, (store) => store.hasAttemptedAutoLogin);
   const [open, setOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const [isSubmittingReport, setIsSubmittingReport] = useState(false);
+  const [reportError, setReportError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { goTo } = useAuthRoutes();
   const router = useRouter();
@@ -73,6 +81,40 @@ export default function MoreActionsMenu({
     }
   };
 
+  const handleOpenReport = () => {
+    setOpen(false);
+    setReportError(null);
+    setIsReportOpen(true);
+  };
+
+  const handleSubmitReport = async (reason: string, details: string) => {
+    if (!reportTargetId) {
+      setReportError('Unable to submit report: missing target identifier.');
+      return;
+    }
+
+    setIsSubmittingReport(true);
+    setReportError(null);
+    try {
+      if (mode === 'user') {
+        await profileStore.blockUser({ reason, details, targetId: reportTargetId });
+      } else {
+        await profileStore.reportAiBot({ reason, details, targetId: reportTargetId });
+      }
+      setIsReportOpen(false);
+      uiStore.showSnackbar('Thanks for your report. Our team will review it shortly.', 'success');
+    } catch (error) {
+      console.error('Failed to submit report', error);
+      setReportError('Could not send report. Please try again later.');
+    } finally {
+      setIsSubmittingReport(false);
+    }
+  };
+
+  const isReportMode = mode !== 'self';
+  const reportDisabled = isReportMode && !reportTargetId;
+  const reportLabel = mode === 'aiAgent' ? 'Report AI agent' : 'Report user';
+
   return (
     <div ref={containerRef} className={`relative ${className ?? ''}`}>
       <Button
@@ -90,17 +132,39 @@ export default function MoreActionsMenu({
           className={`absolute z-50 mt-2 w-44 rounded-xl border border-white/10 bg-neutral-900/95 p-1 text-sm text-white/90 shadow-xl backdrop-blur ${align === 'end' ? 'right-0' : 'left-0'}`}
           role="menu"
         >
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition hover:bg-white/10"
-            onClick={handleLogout}
-            disabled={isLoggingOut}
-          >
-            <LogOut className="size-4" />
-            {isLoggingOut ? 'Logging out…' : 'Log out'}
-          </button>
+          {isReportMode ? (
+            <button
+              type="button"
+              className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition ${reportDisabled ? 'cursor-not-allowed text-white/40' : 'hover:bg-white/10'}`}
+              onClick={reportDisabled ? undefined : handleOpenReport}
+              disabled={reportDisabled}
+            >
+              <Flag className="size-4" />
+              {reportLabel}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition hover:bg-white/10"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+            >
+              <LogOut className="size-4" />
+              {isLoggingOut ? 'Logging out…' : 'Log out'}
+            </button>
+          )}
         </div>
       )}
+      {isReportMode ? (
+        <ReportModal
+          open={isReportOpen}
+          type={mode === 'aiAgent' ? 'aiAgent' : 'user'}
+          onClose={() => setIsReportOpen(false)}
+          onSubmit={handleSubmitReport}
+          isSubmitting={isSubmittingReport}
+          error={reportError}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/ReportModal.tsx
+++ b/src/components/ReportModal.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import ModalShell from "@/components/profile/edit/overview/ModalShell";
+
+const userReportReasons = [
+  "Spam or scam",
+  "Harassment or bullying",
+  "Inappropriate content",
+  "Fake profile",
+  "Other",
+];
+
+const aiAgentReportReasons = [
+  "Spam or misleading",
+  "Hate speech or discrimination",
+  "Violence or threats",
+  "Sexually explicit content",
+  "Harassment or bullying",
+  "Other",
+];
+
+type ReportType = "user" | "aiAgent";
+
+interface ReportModalProps {
+  open: boolean;
+  type: ReportType;
+  onClose: () => void;
+  onSubmit: (reason: string, details: string) => Promise<void> | void;
+  isSubmitting?: boolean;
+  error?: string | null;
+}
+
+export default function ReportModal({
+  open,
+  type,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+  error = null,
+}: ReportModalProps) {
+  const [selectedReason, setSelectedReason] = useState<string | null>(null);
+  const [details, setDetails] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedReason(null);
+      setDetails("");
+    }
+  }, [open]);
+
+  const title = type === "user" ? "Report user" : "Report AI agent";
+  const description =
+    type === "user"
+      ? "Let us know why you believe this profile violates our guidelines."
+      : "Tell us what feels off about this AI agent so our team can review it.";
+
+  const reasons = useMemo(() => {
+    return type === "user" ? userReportReasons : aiAgentReportReasons;
+  }, [type]);
+
+  const handleSubmit = async () => {
+    if (!selectedReason || isSubmitting) return;
+    await onSubmit(selectedReason, details.trim());
+  };
+
+  return (
+    <ModalShell open={open} onBackdrop={onClose}>
+      <div className="space-y-6 p-6">
+        <header className="space-y-2">
+          <h2 className="text-xl font-semibold text-white">{title}</h2>
+          <p className="text-sm text-white/70">{description}</p>
+          {error ? (
+            <p className="text-sm text-red-400">{error}</p>
+          ) : null}
+        </header>
+
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-white/60">
+            Select a reason
+          </p>
+          <div className="grid gap-2">
+            {reasons.map((reason) => {
+              const isActive = selectedReason === reason;
+              return (
+                <button
+                  key={reason}
+                  type="button"
+                  onClick={() => setSelectedReason(reason)}
+                  className={`rounded-2xl border px-4 py-3 text-left text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
+                    isActive
+                      ? "border-white/80 bg-white text-neutral-900 shadow"
+                      : "border-white/10 bg-white/5 text-white/80 hover:border-white/20 hover:bg-white/10"
+                  }`}
+                >
+                  {reason}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-white/60">
+            Additional details
+          </label>
+          <textarea
+            value={details}
+            onChange={(event) => setDetails(event.target.value)}
+            rows={4}
+            placeholder="Provide any extra context (optional)"
+            className="w-full resize-none rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-sm text-white placeholder:text-neutral-500 focus:border-white/40 focus:outline-none"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full px-5 py-2 text-sm font-medium text-white/70 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!selectedReason || isSubmitting}
+            className="rounded-full bg-white px-5 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-white/90 disabled:cursor-not-allowed disabled:bg-white/60"
+          >
+            {isSubmitting ? "Sending…" : "Send report"}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/components/profile/HeaderActions.tsx
+++ b/src/components/profile/HeaderActions.tsx
@@ -27,7 +27,7 @@ export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
                 <Button variant="frostedIcon">
                     <Share2 className="size-5" />
                 </Button>
-                <MoreActionsMenu />
+                <MoreActionsMenu mode="self" />
             </div>
             <div className="flex items-center gap-3">
                 <Button onClick={onEdit} variant="solidWhitePill">

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -12,6 +12,8 @@ interface HeaderBarProps {
   isBusy?: boolean;
   disableFollowAction?: boolean;
   onToggleFollow?: () => void;
+  isCurrentUser?: boolean;
+  profileId?: string;
 }
 
 export default function HeaderBar({
@@ -19,6 +21,8 @@ export default function HeaderBar({
   isBusy,
   disableFollowAction,
   onToggleFollow,
+  isCurrentUser = false,
+  profileId,
 }: HeaderBarProps) {
   const isActionDisabled = disableFollowAction || isBusy || !onToggleFollow;
   const buttonLabel = isBusy
@@ -47,7 +51,10 @@ export default function HeaderBar({
         <Button variant="frostedIcon">
           <Share2 className="size-5" />
         </Button>
-        <MoreActionsMenu />
+        <MoreActionsMenu
+          mode={isCurrentUser ? "self" : "user"}
+          reportTargetId={isCurrentUser ? undefined : profileId}
+        />
       </div>
       <Button
         variant={buttonVariant}

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -158,8 +158,12 @@ export class ProfileService {
     return $api.get(`/profile/${id}/following`, { params });
   }
 
-  public async blockUser(data: { reason?: string, details?: string, targetId: string }): Promise<AxiosResponse<boolean>> {
+  public async blockUser(data: { reason?: string; details?: string; targetId: string }): Promise<AxiosResponse<boolean>> {
     return $api.post(`/reports`, { targetType: 'user', ...data });
+  }
+
+  public async reportAiBot(data: { reason?: string; details?: string; targetId: string }): Promise<AxiosResponse<boolean>> {
+    return $api.post(`/reports`, { targetType: 'ai-bot', ...data });
   }
 
   public async deleteAccount(id: string): Promise<AxiosResponse<boolean>> {

--- a/src/stores/ProfileStore.ts
+++ b/src/stores/ProfileStore.ts
@@ -413,11 +413,23 @@ export class ProfileStore extends BaseStore {
     }
   }
 
-  async blockUser(data: { reason?: string, details?: string, targetId: string }) {
+  async blockUser(data: { reason?: string; details?: string; targetId: string }) {
     try {
       await this.profileService.blockUser(data);
+      return true;
     } catch (error) {
-      console.error(error);
+      console.error("Failed to report user", error);
+      throw error;
+    }
+  }
+
+  async reportAiBot(data: { reason?: string; details?: string; targetId: string }) {
+    try {
+      await this.profileService.reportAiBot(data);
+      return true;
+    } catch (error) {
+      console.error("Failed to report AI agent", error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a reusable report modal for users and AI agents
- show logout only on self pages and surface reporting from other profile menus
- extend profile services/stores to submit reports for users and AI agents

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d914884b008333ae6e1a7add0958d0