### PR TITLE
Add creator profile link support to AI agent highlights

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -70,18 +70,25 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
   }, [isAuthenticated, myBots.length, aiBotStore]);
 
 
+  const userProfileRoute = routes.userProfile;
+
   const highlights = useMemo<Highlight[]>(() => {
     if (!aiBot) return [];
+
+    const creator = aiBot.createdBy;
+    const creatorName = creator ? getUserFullName(creator) : "";
+    const creatorHref = creator?._id ? `${userProfileRoute}/${creator._id}` : undefined;
+
     return [
       {
         title: "Creator Info",
         lines: [
-          { label: "Creator", value: getUserFullName(aiBot.createdBy) },
+          { label: "Creator", value: creatorName, href: creatorHref },
           { label: "Created", value: `${aiBot.createdAt}` },
         ],
       },
-    ]
-  }, [aiBot]);
+    ];
+  }, [aiBot, userProfileRoute]);
 
   const chatHref = aiBot?.chatLink || routes.adminChat;
   const aiBotProfileId = aiBot?._id;

--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -30,7 +30,7 @@ interface ClientAiAgentProfilePageProps {
 }
 
 export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfilePageProps) {
-  const { routes } = useAuthRoutes();
+  const { routes, getProfile } = useAuthRoutes();
   const { aiBotStore, authStore, chatStore } = useRootStore();
   const router = useRouter();
   const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
@@ -68,16 +68,12 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
 
     void aiBotStore.fetchMyAiBots();
   }, [isAuthenticated, myBots.length, aiBotStore]);
-
-
-  const userProfileRoute = routes.userProfile;
-
   const highlights = useMemo<Highlight[]>(() => {
     if (!aiBot) return [];
 
     const creator = aiBot.createdBy;
     const creatorName = creator ? getUserFullName(creator) : "";
-    const creatorHref = creator?._id ? `${userProfileRoute}/${creator._id}` : undefined;
+    const creatorHref = creator?._id ? getProfile(creator._id) : undefined;
 
     return [
       {
@@ -88,7 +84,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
         ],
       },
     ];
-  }, [aiBot, userProfileRoute]);
+  }, [aiBot, getProfile]);
 
   const chatHref = aiBot?.chatLink || routes.adminChat;
   const aiBotProfileId = aiBot?._id;

--- a/src/components/ai-agent/HighlightCard.tsx
+++ b/src/components/ai-agent/HighlightCard.tsx
@@ -9,7 +9,18 @@ export default function HighlightCard({ item }: { item: Highlight }) {
                 {item.lines.map((line) => (
                     <div key={line.label} className="flex items-start justify-between gap-4">
                         <dt className="text-white/50">{line.label}</dt>
-                        <dd className="text-right text-white">{line.value}</dd>
+                        <dd className="text-right text-white">
+                            {line.href ? (
+                                <a
+                                    href={line.href}
+                                    className="text-white underline decoration-white/40 underline-offset-2 transition hover:decoration-white"
+                                >
+                                    {line.value}
+                                </a>
+                            ) : (
+                                line.value
+                            )}
+                        </dd>
                     </div>
                 ))}
             </dl>

--- a/src/helpers/data/ai-agent.ts
+++ b/src/helpers/data/ai-agent.ts
@@ -5,7 +5,11 @@ export const highlights: Highlight[] = [
     {
         title: "Creator Info",
         lines: [
-            { label: "Handle", value: "@aiAgent" },
+            {
+                label: "Handle",
+                value: "@aiAgent",
+                href: "https://example.com/@aiAgent",
+            },
             { label: "Role", value: "Adaptive companion" },
             { label: "Created", value: "02/15/2026 09:41" },
         ],

--- a/src/helpers/types/ai-agent.ts
+++ b/src/helpers/types/ai-agent.ts
@@ -1,3 +1,3 @@
-export type HighlightLine = { label: string; value: string };
+export type HighlightLine = { label: string; value: string; href?: string };
 export type Highlight = { title: string; lines: HighlightLine[] };
 export type Opening = { title: string; description: string };


### PR DESCRIPTION
## Summary
- allow highlight entries to include optional links
- render creator details with a link to their profile on the AI agent page
- update sample highlight data to include a creator handle link

## Testing
- npm run lint *(fails: pre-existing lint errors around any types and unused values)*

------
https://chatgpt.com/codex/tasks/task_e_68d918740ef88333aec2d48bc3aecd21