### PR TITLE
Add delete confirmation flow for owned AI agent profiles

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -34,6 +34,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
   const { aiBotStore, authStore, chatStore } = useRootStore();
   const router = useRouter();
   const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
+  const discoverRoute = routes.discover;
 
   const aiBot = useStoreData(aiBotStore, (store) => store.selectAiBot);
   const isLoading = useStoreData(aiBotStore, (store) => store.isAiUserLoading);
@@ -135,6 +136,10 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
     }
   }, [aiBotProfileId, chatStore, isChatLoading, router, routes.adminChat]);
 
+  const handleAiAgentDeleted = useCallback(() => {
+    router.push(discoverRoute);
+  }, [router, discoverRoute]);
+
   return (
     <AppShell>
       <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
@@ -160,7 +165,13 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
               <Button type="button" variant="frostedIcon" aria-label="Share agent">
                 <Share2 className="size-5" />
               </Button>
-              <MoreActionsMenu mode="aiAgent" reportTargetId={aiBotProfileId} />
+              <MoreActionsMenu
+                mode="aiAgent"
+                reportTargetId={aiBotProfileId}
+                aiAgentId={aiBotProfileId}
+                canDeleteAiAgent={isCreator}
+                onAiAgentDeleted={handleAiAgentDeleted}
+              />
             </div>
             {canEdit && (
               <div className="flex items-center gap-3">

--- a/src/components/MoreActionsMenu.tsx
+++ b/src/components/MoreActionsMenu.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Flag, LogOut, MoreHorizontal } from 'lucide-react';
+import { Flag, LogOut, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Button, type ButtonVariant } from '@/components/ui/Button';
 import { useRootStore, useStoreData } from '@/stores/StoreProvider';
 import { useAuthRoutes } from '@/helpers/hooks/useAuthRoutes';
 import ReportModal from '@/components/ReportModal';
+import ModalShell from '@/components/profile/edit/overview/ModalShell';
 
 interface MoreActionsMenuProps {
   buttonAriaLabel?: string;
@@ -15,6 +16,9 @@ interface MoreActionsMenuProps {
   className?: string;
   mode?: 'self' | 'user' | 'aiAgent';
   reportTargetId?: string;
+  aiAgentId?: string;
+  canDeleteAiAgent?: boolean;
+  onAiAgentDeleted?: () => void;
 }
 
 export default function MoreActionsMenu({
@@ -24,14 +28,20 @@ export default function MoreActionsMenu({
   className,
   mode = 'self',
   reportTargetId,
+  aiAgentId,
+  canDeleteAiAgent = false,
+  onAiAgentDeleted,
 }: MoreActionsMenuProps) {
-  const { authStore, profileStore, uiStore } = useRootStore();
+  const { authStore, profileStore, uiStore, aiBotStore } = useRootStore();
   const hasAttemptedAutoLogin = useStoreData(authStore, (store) => store.hasAttemptedAutoLogin);
   const [open, setOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isReportOpen, setIsReportOpen] = useState(false);
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
   const [reportError, setReportError] = useState<string | null>(null);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { goTo } = useAuthRoutes();
   const router = useRouter();
@@ -111,9 +121,42 @@ export default function MoreActionsMenu({
     }
   };
 
+  const handleOpenDelete = () => {
+    setOpen(false);
+    setDeleteError(null);
+    setIsDeleteOpen(true);
+  };
+
+  const handleCloseDelete = () => {
+    if (isDeleting) return;
+    setIsDeleteOpen(false);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!aiAgentId) {
+      setDeleteError('Unable to delete AI agent: missing target identifier.');
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      await aiBotStore.deleteBot(aiAgentId);
+      setIsDeleteOpen(false);
+      uiStore.showSnackbar('AI agent deleted', 'success');
+      onAiAgentDeleted?.();
+    } catch (error) {
+      console.error('Failed to delete AI agent', error);
+      setDeleteError('Could not delete this AI agent. Please try again later.');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   const isReportMode = mode !== 'self';
   const reportDisabled = isReportMode && !reportTargetId;
   const reportLabel = mode === 'aiAgent' ? 'Report AI agent' : 'Report user';
+  const canShowDeleteOption = mode === 'aiAgent' && canDeleteAiAgent;
 
   return (
     <div ref={containerRef} className={`relative ${className ?? ''}`}>
@@ -133,15 +176,27 @@ export default function MoreActionsMenu({
           role="menu"
         >
           {isReportMode ? (
-            <button
-              type="button"
-              className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition ${reportDisabled ? 'cursor-not-allowed text-white/40' : 'hover:bg-white/10'}`}
-              onClick={reportDisabled ? undefined : handleOpenReport}
-              disabled={reportDisabled}
-            >
-              <Flag className="size-4" />
-              {reportLabel}
-            </button>
+            <>
+              {canShowDeleteOption ? (
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-red-400 transition hover:bg-red-500/10"
+                  onClick={handleOpenDelete}
+                >
+                  <Trash2 className="size-4" />
+                  Delete AI agent
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition ${reportDisabled ? 'cursor-not-allowed text-white/40' : 'hover:bg-white/10'}`}
+                onClick={reportDisabled ? undefined : handleOpenReport}
+                disabled={reportDisabled}
+              >
+                <Flag className="size-4" />
+                {reportLabel}
+              </button>
+            </>
           ) : (
             <button
               type="button"
@@ -164,6 +219,34 @@ export default function MoreActionsMenu({
           isSubmitting={isSubmittingReport}
           error={reportError}
         />
+      ) : null}
+      {canShowDeleteOption ? (
+        <ModalShell open={isDeleteOpen} onBackdrop={handleCloseDelete}>
+          <div className="space-y-6 px-1 pb-6 pt-6 md:px-6">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-white">Delete AI agent?</h2>
+              <p className="text-sm text-white/70">
+                Deleting this AI agent will permanently remove all of its chats, conversations, and related information for every
+                user. This action cannot be undone. Are you sure you want to continue?
+              </p>
+            </div>
+            {deleteError ? <p className="text-sm text-red-400">{deleteError}</p> : null}
+            <div className="flex justify-end gap-3">
+              <Button type="button" variant="outline" onClick={handleCloseDelete} disabled={isDeleting}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="solidWhite"
+                className="bg-red-600 text-white hover:bg-red-500"
+                onClick={handleConfirmDelete}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        </ModalShell>
       ) : null}
     </div>
   );

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -569,12 +569,21 @@ export class AiBotStore extends BaseStore {
     try {
       await this.profileService.deleteAiBot(id);
       runInAction(() => {
-        this.myBots = this.myBots.filter(b => b._id !== id);
+        this.myBots = this.myBots.filter((bot) => bot._id !== id);
+        this.userAiBots = this.userAiBots.filter((bot) => bot._id !== id);
+        this.bots = this.bots.filter((bot) => bot._id !== id);
+        if (this.selectAiBot?._id === id) {
+          this.selectAiBot = null;
+        }
+        if (this.createdBot?._id === id) {
+          this.createdBot = null;
+        }
+        this.botDetails = null;
+        this.botPhotos = [];
         this.notify();
       });
-      // uiStore.showSnackbar("Deleted", "success");
     } catch (e) {
-      // uiStore.showSnackbar("Failed", "error");
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a delete action with confirmation modal to the AI agent actions menu for creators
- redirect back to discovery after deletion from the AI agent profile page
- clear related store state when an AI agent is removed

## Testing
- npm run lint *(fails: existing lint errors around `any` usage and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68d919c2974c8333b9d84ea1cc1d08c3