### PR TITLE
Add sending state for chat messages

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -69,6 +69,7 @@ export default function ChatPage() {
   const pinnedMessages = useStoreData(chatStore, (store) => store.pinnedMessages);
   const hasMoreMessages = useStoreData(chatStore, (store) => store.hasMoreMessages);
   const selectedChat = useStoreData(chatStore, (store) => store.selectedChat);
+  const isSendingMessage = useStoreData(chatStore, (store) => store.isSendingMessage);
   const myId = useStoreData(authStore, (store) => store.user?.id ?? '');
 
   const [isLoadingConversation, setIsLoadingConversation] = useState(false);
@@ -325,6 +326,7 @@ export default function ChatPage() {
             <MessageInput
               onSend={handleSend}
               placeholder={chatId ? `Message ${conversationTitle}` : 'Select a chat to start messaging'}
+              isSending={isSendingMessage}
             />
           </div>
         </div>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -7,17 +7,18 @@ import { Button } from '@/components/ui/Button';
 
 type Props = {
     placeholder?: string;
-    onSend?: (text: string) => void;
+    onSend?: (text: string) => Promise<void> | void;
+    isSending?: boolean;
 };
 
 
-export default function MessageInput({ placeholder = 'Say something...', onSend }: Props) {
+export default function MessageInput({ placeholder = 'Say something...', onSend, isSending = false }: Props) {
     const [value, setValue] = useState('');
-    const submit = (e: React.FormEvent) => {
+    const submit = async (e: React.FormEvent) => {
         e.preventDefault();
         const v = value.trim();
         if (!v) return;
-        onSend?.(v);
+        await onSend?.(v);
         setValue('');
     };
     return (
@@ -28,8 +29,9 @@ export default function MessageInput({ placeholder = 'Say something...', onSend 
                     onChange={(e) => setValue(e.target.value)}
                     className="flex-1 rounded-2xl border border-white/10 bg-transparent px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
                     placeholder={placeholder}
+                    disabled={isSending}
                 />
-                <Button type="submit" variant="solidWhite">
+                <Button type="submit" variant="solidWhite" disabled={isSending}>
                     Send
                 </Button>
             </div>

--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -29,6 +29,7 @@ export class ChatStore extends BaseStore {
   hasMoreMessages = true;
   hasMoreChats = true;
   isLoadingChats = false;
+  isSendingMessage = false;
 
   isApiCheckedNewMessages = false;
 
@@ -291,6 +292,9 @@ export class ChatStore extends BaseStore {
     images?: any, //todo refactor type
   ) {
     try {
+      runInAction(() => {
+        this.isSendingMessage = true;
+      });
       const { data } = await this.chatService.sendMessage(
         message,
         chatId,
@@ -311,6 +315,11 @@ export class ChatStore extends BaseStore {
     } catch (err) {
       this.root.uiStore.showSnackbar("Failed", "error");
       console.error("Ошибка при отправке сообщения:", err);
+    } finally {
+      runInAction(() => {
+        this.isSendingMessage = false;
+      });
+      this.notify();
     }
   }
 


### PR DESCRIPTION
## Summary
- track a sending state in the chat store and expose it to the chat page
- disable the chat message input and submit button while a message is being sent
- wait for the send action to resolve before clearing the input so the UI updates with the backend response

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d92f13d0ac8333a05cda5fc58be5aa