### PR TITLE
Fix duplicate chat messages and typing indicator updates

### DIFF
--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -317,7 +317,10 @@ export class ChatStore extends BaseStore {
       } as MessageDTO;
 
       runInAction(() => {
-        this.messages.push(messageData);
+        const exists = this.messages.some((message) => message._id === messageData._id);
+        if (!exists) {
+          this.messages.push(messageData);
+        }
       });
       this.notify();
     } catch (err) {

--- a/src/stores/OnlineStore.ts
+++ b/src/stores/OnlineStore.ts
@@ -268,12 +268,14 @@ export class OnlineStore extends BaseStore {
         this.typingUsers = this.typingUsers.filter(u => u.userId !== userId);
       }
     });
+    this.notify();
   }
 
   clearTypingUsers() {
     runInAction(() => {
       this.typingUsers = [];
     });
+    this.notify();
   }
 
   getTypingUsers() { return this.typingUsers; }


### PR DESCRIPTION
## Summary
- prevent locally sent chat messages from being duplicated when the server echoes them back
- trigger store notifications when typing users list changes so the typing indicator re-renders

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d943016070833393343c6fd72aaf4d