### PR TITLE
Fix chat auto-scroll handling for new messages

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -183,25 +183,28 @@ export default function ChatPage() {
     }
   }, [chatId, chatStore, isLoadingMore, messages.length]);
 
+  const messageCount = messages.length;
+  const lastMessageId = messageCount ? messages[messageCount - 1]?._id : undefined;
+
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container || !messages.length) {
-      previousLastMessageIdRef.current = messages[messages.length - 1]?._id;
+
+    if (!container || !messageCount) {
+      previousLastMessageIdRef.current = lastMessageId;
       previousChatIdRef.current = chatId;
       return;
     }
 
-    const currentLastMessageId = messages[messages.length - 1]?._id;
     const chatHasChanged = chatId && chatId !== previousChatIdRef.current;
-    const hasNewLastMessage = currentLastMessageId && currentLastMessageId !== previousLastMessageIdRef.current;
+    const hasNewLastMessage = lastMessageId && lastMessageId !== previousLastMessageIdRef.current;
 
     if (chatHasChanged || hasNewLastMessage) {
       container.scrollTop = container.scrollHeight;
     }
 
-    previousLastMessageIdRef.current = currentLastMessageId;
+    previousLastMessageIdRef.current = lastMessageId;
     previousChatIdRef.current = chatId;
-  }, [chatId, messages]);
+  }, [chatId, lastMessageId, messageCount]);
 
   const conversationTitle = useMemo(() => {
     if (!selectedChat) return 'Chat';


### PR DESCRIPTION
## Summary
- derive chat message count and last message id to drive scroll effect updates
- ensure the chat view scrolls to the newest message when messages are sent or received without reacting to history loads

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d94c0eaa5c8333b75ae557804a9dcf