### PR TITLE
Improve chat auto scroll reliability

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode, Ref } from 'react';
 import type { MessageDTO } from '@/helpers/types';
 import MessageBubble from './MessageBubble';
 
@@ -10,6 +11,9 @@ type MessageListProps = {
   onPinMessage: (message: MessageDTO) => void;
   onUnpinMessage: (messageId: string) => void;
   resolveSenderName: (message: MessageDTO) => string;
+  children?: ReactNode;
+  containerRef?: Ref<HTMLDivElement>;
+  bottomSentinelRef?: Ref<HTMLDivElement>;
 };
 
 export default function MessageList({
@@ -19,9 +23,12 @@ export default function MessageList({
   onPinMessage,
   onUnpinMessage,
   resolveSenderName,
+  children,
+  containerRef,
+  bottomSentinelRef,
 }: MessageListProps) {
   return (
-    <div className="space-y-4">
+    <div ref={containerRef} className="space-y-4">
       {messages.map((message) => (
         <MessageBubble
           key={message._id}
@@ -33,6 +40,8 @@ export default function MessageList({
           onUnpin={onUnpinMessage}
         />
       ))}
+      {children}
+      <div ref={bottomSentinelRef} aria-hidden className="h-px w-full" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a bottom sentinel inside the chat message list so the view always targets the latest bubble
- shift the chat page auto-scroll logic to requestAnimationFrame/useLayoutEffect, including a resize observer, and allow the scroll container to shrink with min-h-0

## Testing
- npm run lint *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d94ed9a0a08333935ce16bcb5399d5