### PR TITLE
Improve chat auto-scroll behavior

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -152,11 +152,6 @@ export default function ChatPage() {
     };
   }, [chatId, onlineStore]);
 
-  const handleSend = useCallback(async (text: string) => {
-    if (!chatId || !text.trim()) return;
-    await chatStore.sendMessage(text, chatId);
-  }, [chatId, chatStore]);
-
   const handleTyping = useCallback(() => {
     if (!chatId) return;
     onlineStore.emitTyping(chatId);
@@ -215,10 +210,19 @@ export default function ChatPage() {
     }
 
     scrollAnimationFrameRef.current = requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight;
       anchor.scrollIntoView({ block: 'end', inline: 'nearest', behavior: 'auto' });
       scrollAnimationFrameRef.current = null;
     });
   }, []);
+
+  useEffect(() => {
+    if (!chatId || isLoadingConversation || !messageCount) {
+      return;
+    }
+
+    queueScrollToBottom();
+  }, [chatId, isLoadingConversation, messageCount, queueScrollToBottom]);
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
@@ -239,6 +243,13 @@ export default function ChatPage() {
     previousLastMessageIdRef.current = lastMessageId;
     previousChatIdRef.current = chatId;
   }, [chatId, lastMessageId, messageCount, queueScrollToBottom]);
+
+  const handleSend = useCallback(async (text: string) => {
+    if (!chatId || !text.trim()) return;
+
+    await chatStore.sendMessage(text, chatId);
+    queueScrollToBottom();
+  }, [chatId, chatStore, queueScrollToBottom]);
 
   const messageListElement = messageListRef.current;
 

--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -319,7 +319,7 @@ export class ChatStore extends BaseStore {
       runInAction(() => {
         const exists = this.messages.some((message) => message._id === messageData._id);
         if (!exists) {
-          this.messages.push(messageData);
+          this.messages = [...this.messages, messageData];
         }
       });
       this.notify();
@@ -435,12 +435,19 @@ export class ChatStore extends BaseStore {
 
     if (this.selectedChat?._id !== incomingChatId) return;
 
+    let didAppendMessage = false;
+
     runInAction(() => {
       const exists = this.messages.some(m => m._id === incoming._id);
       if (!exists) {
-        this.messages.push(incoming);
+        this.messages = [...this.messages, incoming];
+        didAppendMessage = true;
       }
     });
+
+    if (didAppendMessage) {
+      this.notify();
+    }
   };
 
   private handleEditedMessage = (updatedMessage: any) => {


### PR DESCRIPTION
## Summary
- ensure the chat view scrolls to the latest message when the conversation loads or a message is sent
- keep the scroll container aligned to the bottom by adjusting the scroll routine
- update the chat store to append messages immutably so UI updates and scrolling triggers reliably

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d951815acc833396b8e114c3f4407e