### PR TITLE
Enable AI bot cards to open chat directly

### DIFF
--- a/src/components/AiCard.tsx
+++ b/src/components/AiCard.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { MessageSquare } from 'lucide-react';
+import { Loader2, MessageSquare } from 'lucide-react';
 
 export type HoverSwapCardProps = {
   src?: string;             // делаем опциональным — будет заглушка, если пусто
@@ -11,6 +11,8 @@ export type HoverSwapCardProps = {
   views?: number | string;
   hoverText?: string;
   href?: string;
+  onChatNow?: () => void;
+  isChatLoading?: boolean;
 };
 
 export default function HoverSwapCard({
@@ -20,7 +22,22 @@ export default function HoverSwapCard({
   views,
   hoverText,
   href,
+  onChatNow,
+  isChatLoading = false,
 }: HoverSwapCardProps) {
+  const handleChatClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!onChatNow) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!isChatLoading) {
+      onChatNow();
+    }
+  };
+
   const CardInner = (
     <div className="group relative isolate w-full aspect-[11/14] overflow-hidden rounded-3xl bg-zinc-900 shadow-xl ring-1 ring-black/10 transition-all hover:ring-black/20 hover:z-10">
       {/* Изображение или заглушка */}
@@ -83,10 +100,19 @@ export default function HoverSwapCard({
           </div>
 
           <div className="w-full">
-            <div className="flex w-full items-center justify-center gap-2 rounded-full bg-white/95 py-3 text-sm font-semibold text-zinc-900 shadow [transition:background-color_200ms_ease] hover:bg-white">
-              <MessageSquare className="size-4" aria-hidden />
-              Chat Now
-            </div>
+            <button
+              type="button"
+              onClick={handleChatClick}
+              disabled={isChatLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-full bg-white/95 py-3 text-sm font-semibold text-zinc-900 shadow transition-colors duration-200 hover:bg-white disabled:cursor-not-allowed disabled:opacity-80"
+            >
+              {isChatLoading ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden />
+              ) : (
+                <MessageSquare className="size-4" aria-hidden />
+              )}
+              <span>{isChatLoading ? 'Opening…' : 'Chat Now'}</span>
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/ui/CardRailOneRow.tsx
+++ b/src/components/ui/CardRailOneRow.tsx
@@ -12,6 +12,8 @@ type Item = {
   views?: number | string;
   hoverText?: string;
   href?: string;
+  onChatNow?: () => void;
+  isChatLoading?: boolean;
 };
 
 type Props = {
@@ -91,6 +93,8 @@ export default function CardRailOneRow({
                 views={it.views}
                 hoverText={it.hoverText}
                 href={it.href}
+                onChatNow={it.onChatNow}
+                isChatLoading={it.isChatLoading}
               />
             </div>
           ))}

--- a/src/components/ui/CardRailTwoRows.tsx
+++ b/src/components/ui/CardRailTwoRows.tsx
@@ -12,6 +12,8 @@ type Item = {
   views?: number | string;
   hoverText?: string;
   href?: string;
+  onChatNow?: () => void;
+  isChatLoading?: boolean;
 };
 
 type Props = {
@@ -97,6 +99,8 @@ export default function CardRailTwoRows({
                 views={it.views}
                 hoverText={it.hoverText}
                 href={it.href}
+                onChatNow={it.onChatNow}
+                isChatLoading={it.isChatLoading}
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary
- add optional chat handler to AI bot cards and show a loading spinner while opening a conversation
- wire landing page cards to create/fetch the chat for the selected bot and navigate to the admin chat view
- expose the new handler through card rail components so existing usage keeps working

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d95da2eef083338830ae1d17ea3d8a