### PR TITLE
Add AiPair legal and contact pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "AiPair | Contact",
+  description: "Get in touch with the AiPair team for support, partnerships, press inquiries, or community feedback.",
+};
+
+const contactChannels = [
+  {
+    title: "Support & Feedback",
+    description:
+      "Need help using AiPair or have suggestions to share? Email our support team and we will respond within 2 business days.",
+    actionLabel: "feedback@aipair.pro",
+    actionHref: "mailto:feedback@aipair.pro",
+  },
+  {
+    title: "Partnerships",
+    description:
+      "Interested in integrating AiPair characters into your product or building a custom experience? Reach out to discuss collaborations.",
+    actionLabel: "Partner with us",
+    actionHref: "mailto:feedback@aipair.pro?subject=Partnership%20with%20AiPair",
+  },
+  {
+    title: "Press",
+    description:
+      "Members of the media can contact us for interviews, product details, or assets about AiPair and our AI companion mission.",
+    actionLabel: "Request press info",
+    actionHref: "mailto:feedback@aipair.pro?subject=Press%20Inquiry",
+  },
+];
+
+const faqs = [
+  {
+    question: "How quickly will I receive a response?",
+    answer:
+      "We aim to reply to all emails within 48 hours, Monday through Friday. Complex product questions may take longer, but you will hear back from us.",
+  },
+  {
+    question: "Do you have a community space?",
+    answer:
+      "Join the conversation with other creators and fans on our upcoming AiPair Discord community. Sign up for updates on the landing page.",
+  },
+  {
+    question: "Where is the AiPair team located?",
+    answer: "We are a distributed team with contributors across North America and Europe.",
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 py-16 text-white">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <header className="mb-16 text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">Contact</p>
+          <h1 className="mt-3 text-3xl font-bold md:text-4xl">We would love to hear from you</h1>
+          <p className="mt-4 text-sm text-white/70">
+            Reach out for product support, business opportunities, or to tell us how AiPair can improve your AI companion experience.
+          </p>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-3">
+          {contactChannels.map((channel) => (
+            <div key={channel.title} className="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-neutral-900/60 p-6">
+              <div className="space-y-3">
+                <h2 className="text-lg font-semibold text-white">{channel.title}</h2>
+                <p className="text-sm leading-relaxed text-white/70">{channel.description}</p>
+              </div>
+              <a
+                className="mt-6 inline-flex items-center justify-start text-sm font-semibold text-[#c7a7ff] hover:text-white"
+                href={channel.actionHref}
+              >
+                {channel.actionLabel}
+              </a>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-16 grid gap-10 rounded-3xl border border-white/10 bg-neutral-900/60 p-8 md:grid-cols-2">
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-white">Additional resources</h2>
+            <ul className="space-y-3 text-sm text-white/70">
+              <li>
+                Review our <Link className="text-[#c7a7ff] underline" href="/terms">Terms of Service</Link> to understand platform usage.
+              </li>
+              <li>
+                Learn how we protect your information in the <Link className="text-[#c7a7ff] underline" href="/privacy">Privacy Policy</Link>.
+              </li>
+              <li>
+                Follow product updates and tutorials on our upcoming blog (launching soon!).
+              </li>
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-white">Quick answers</h2>
+            <div className="space-y-4">
+              {faqs.map((faq) => (
+                <div key={faq.question} className="rounded-2xl border border-white/10 bg-neutral-950/60 p-4">
+                  <h3 className="text-sm font-semibold text-white">{faq.question}</h3>
+                  <p className="mt-2 text-sm text-white/70">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <footer className="mt-16 text-center text-xs text-white/60">
+          <p>
+            Prefer to talk live? Keep an eye on your inbox for upcoming community sessions hosted by the AiPair team.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,142 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "AiPair | Privacy Policy",
+  description: "Learn how AiPair collects, uses, and protects personal data across our AI companion experiences.",
+};
+
+const sections = [
+  {
+    title: "1. Overview",
+    content: (
+      <p>
+        This Privacy Policy explains how AiPair Inc. (&ldquo;AiPair&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;) collects, uses, and shares information when you
+        use AiPair products, websites, and services. By accessing AiPair, you consent to the practices described in this
+        policy.
+      </p>
+    ),
+  },
+  {
+    title: "2. Information We Collect",
+    content: (
+      <ul className="list-disc space-y-2 pl-5">
+        <li>
+          <strong>Account details:</strong> name, email, avatar, and password or federated identity tokens when you register
+          or authenticate.
+        </li>
+        <li>
+          <strong>Usage data:</strong> interactions with AI companions, session metadata, and device information such as
+          browser type and language.
+        </li>
+        <li>
+          <strong>Communications:</strong> any messages you send to our support team or feedback email.
+        </li>
+      </ul>
+    ),
+  },
+  {
+    title: "3. How We Use Information",
+    content: (
+      <ul className="list-disc space-y-2 pl-5">
+        <li>Provide, personalize, and improve AI conversations and recommendations.</li>
+        <li>Monitor platform stability, security, and compliance with our Terms.</li>
+        <li>Communicate updates, respond to support inquiries, and send transactional notices.</li>
+        <li>Develop new features and conduct aggregated analytics to understand engagement trends.</li>
+      </ul>
+    ),
+  },
+  {
+    title: "4. Sharing & Disclosure",
+    content: (
+      <p>
+        We do not sell personal data. We may share limited information with vendors that help us operate AiPair (for example,
+        cloud hosting or customer support tools) under contracts that require safeguarding your data. We may disclose
+        information if required by law or to protect AiPair, our users, or the public.
+      </p>
+    ),
+  },
+  {
+    title: "5. Data Retention",
+    content: (
+      <p>
+        Conversation data and account records are retained for as long as your account remains active and as necessary to
+        provide our services. You may request deletion of your account and associated data by contacting
+        <a className="text-[#6f2da8] underline" href="mailto:feedback@aipair.pro"> feedback@aipair.pro</a>. We may retain
+        certain information to comply with legal obligations or resolve disputes.
+      </p>
+    ),
+  },
+  {
+    title: "6. Your Choices",
+    content: (
+      <ul className="list-disc space-y-2 pl-5">
+        <li>Update profile and privacy settings directly in your AiPair dashboard.</li>
+        <li>Control memory features on a per-conversation basis within the product.</li>
+        <li>Opt-out of marketing communications by using the unsubscribe link in our emails.</li>
+        <li>Request data access, portability, or deletion by emailing <a className="text-[#6f2da8] underline" href="mailto:feedback@aipair.pro">feedback@aipair.pro</a>.</li>
+      </ul>
+    ),
+  },
+  {
+    title: "7. Security",
+    content: (
+      <p>
+        We implement technical and organizational safeguards such as encryption in transit, access controls, and regular
+        security reviews. No system is fully secure, so we encourage you to use strong passwords and protect your devices.
+      </p>
+    ),
+  },
+  {
+    title: "8. International Users",
+    content: (
+      <p>
+        AiPair is operated from the United States and may process information outside your jurisdiction. By using AiPair, you
+        consent to the transfer of information to the U.S. and other countries where we or our vendors operate.
+      </p>
+    ),
+  },
+  {
+    title: "9. Changes to this Policy",
+    content: (
+      <p>
+        We may update this Privacy Policy periodically. Material changes will be posted on this page with a revised effective
+        date. Continued use of AiPair after changes take effect indicates your acceptance.
+      </p>
+    ),
+  },
+  {
+    title: "10. Contact",
+    content: (
+      <p>
+        If you have questions about privacy at AiPair, contact us at <a className="text-[#6f2da8] underline" href="mailto:feedback@aipair.pro">feedback@aipair.pro</a> or via our <Link className="text-[#6f2da8] underline" href="/contact">Contact page</Link>.
+      </p>
+    ),
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 py-16 text-white">
+      <div className="mx-auto w-full max-w-4xl px-6">
+        <header className="mb-12 space-y-4 text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">AiPair Legal</p>
+          <h1 className="text-3xl font-bold md:text-4xl">Privacy Policy</h1>
+          <p className="text-sm text-white/70">Effective date: {new Date().toLocaleDateString()}</p>
+        </header>
+
+        <div className="space-y-8 rounded-3xl border border-white/10 bg-neutral-900/60 p-8 text-sm leading-relaxed text-white/80">
+          {sections.map((section) => (
+            <section key={section.title} className="space-y-3">
+              <h2 className="text-lg font-semibold text-white">{section.title}</h2>
+              <div className="space-y-3 text-white/80">{section.content}</div>
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-12 text-center text-xs text-white/60">
+          <p>© {new Date().getFullYear()} AiPair. All rights reserved.</p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "AiPair | Terms of Service",
+  description:
+    "Review the Terms of Service for AiPair to understand the rules that govern the use of our AI companion platform.",
+};
+
+const sections = [
+  {
+    title: "1. Introduction",
+    content: (
+      <p>
+        These Terms of Service (&ldquo;Terms&rdquo;) govern your access to and use of AiPair, the conversational AI platform provided by
+        AiPair Inc. (&ldquo;AiPair&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;, or &ldquo;our&rdquo;). By accessing or using AiPair you agree to be bound by these Terms.
+        If you do not agree, you may not use the service.
+      </p>
+    ),
+  },
+  {
+    title: "2. Eligibility & Accounts",
+    content: (
+      <p>
+        You must be at least 13 years old to use AiPair. Creating an account requires accurate, current information. You are
+        responsible for maintaining the confidentiality of your login credentials and for all activity that occurs under your
+        account.
+      </p>
+    ),
+  },
+  {
+    title: "3. Acceptable Use",
+    content: (
+      <ul className="list-disc space-y-2 pl-5">
+        <li>No reverse engineering, scraping, or automated collection of platform data.</li>
+        <li>No harassment, hate speech, or unlawful content shared with AiPair or other users.</li>
+        <li>No attempts to circumvent security features or access another user&apos;s account.</li>
+        <li>
+          You may not use AiPair to develop or distribute competing models or datasets without prior written consent from
+          AiPair.
+        </li>
+      </ul>
+    ),
+  },
+  {
+    title: "4. Intellectual Property",
+    content: (
+      <p>
+        AiPair retains all rights, title, and interest in the platform, including software, interfaces, and branding. By
+        submitting content, you grant AiPair a non-exclusive, worldwide, royalty-free license to use that content solely for
+        operating and improving the service. You remain responsible for the legality of the content you submit.
+      </p>
+    ),
+  },
+  {
+    title: "5. Subscriptions & Billing",
+    content: (
+      <p>
+        AiPair may offer free and paid plans. Paid plans renew automatically at the published rate unless you cancel before
+        the renewal date. All fees are non-refundable unless required by law. We reserve the right to change pricing with
+        reasonable notice.
+      </p>
+    ),
+  },
+  {
+    title: "6. Privacy",
+    content: (
+      <p>
+        Our <Link className="text-[#6f2da8] underline" href="/privacy">Privacy Policy</Link> describes how we collect and use
+        your data. By using AiPair you consent to those practices.
+      </p>
+    ),
+  },
+  {
+    title: "7. Disclaimers & Limitation of Liability",
+    content: (
+      <p>
+        AiPair is provided on an &ldquo;as is&rdquo; basis without warranties of any kind. We do not guarantee accuracy, availability, or
+        that conversations will meet your expectations. To the fullest extent permitted by law, AiPair is not liable for any
+        indirect, incidental, special, or consequential damages arising from your use of the service.
+      </p>
+    ),
+  },
+  {
+    title: "8. Termination",
+    content: (
+      <p>
+        We may suspend or terminate your access to AiPair if you violate these Terms or engage in harmful behavior. You may
+        cancel your account at any time through your settings or by contacting us at <a href="mailto:feedback@aipair.pro"
+        className="text-[#6f2da8] underline">feedback@aipair.pro</a>.
+      </p>
+    ),
+  },
+  {
+    title: "9. Changes to these Terms",
+    content: (
+      <p>
+        AiPair may update these Terms to reflect changes in our services or legal requirements. When we make material
+        updates, we will post a notice on this page and update the effective date below. Continued use after changes become
+        effective constitutes acceptance of the updated Terms.
+      </p>
+    ),
+  },
+  {
+    title: "10. Contact",
+    content: (
+      <p>
+        For questions about these Terms, contact us at <a href="mailto:feedback@aipair.pro" className="text-[#6f2da8]
+        underline">feedback@aipair.pro</a> or visit our <Link className="text-[#6f2da8] underline" href="/contact">Contact
+        page</Link>.
+      </p>
+    ),
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 py-16 text-white">
+      <div className="mx-auto w-full max-w-4xl px-6">
+        <header className="mb-12 space-y-4 text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/60">AiPair Legal</p>
+          <h1 className="text-3xl font-bold md:text-4xl">Terms of Service</h1>
+          <p className="text-sm text-white/70">Effective date: {new Date().toLocaleDateString()}</p>
+        </header>
+
+        <div className="space-y-8 rounded-3xl border border-white/10 bg-neutral-900/60 p-8 text-sm leading-relaxed text-white/80">
+          {sections.map((section) => (
+            <section key={section.title} className="space-y-3">
+              <h2 className="text-lg font-semibold text-white">{section.title}</h2>
+              <div className="space-y-3 text-white/80">{section.content}</div>
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-12 text-center text-xs text-white/60">
+          <p>© {new Date().getFullYear()} AiPair. All rights reserved.</p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/helpers/hooks/useAuthRoutes.ts
+++ b/src/helpers/hooks/useAuthRoutes.ts
@@ -18,9 +18,9 @@ const ROUTES = {
   landingPricing: '#pricing',
   landingFaq: '#faq',
   landingCta: '#cta',
-  terms: '#',
-  privacy: '#',
-  contact: '#',
+  terms: '/terms',
+  privacy: '/privacy',
+  contact: '/contact',
   placeholder: '#',
 } as const;
 


### PR DESCRIPTION
## Summary
- add dedicated Terms of Service, Privacy Policy, and Contact pages with AiPair-specific content and styling
- update shared route helper so footer links and auth copy point to the new legal and contact destinations

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68d964100ab88333bf347112bafa40c7