### PR TITLE
Fix async param handling in admin profile routes

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/page.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/page.tsx
@@ -1,13 +1,16 @@
 import ClientAiAgentProfilePage from "./ClientAiAgentProfilePage";
 
 type PageParams = {
-  params: {
+  params: Promise<{
     id: string | string[];
-  };
+  }>;
 };
 
-export default function Page({ params }: PageParams) {
-  const aiBotId = Array.isArray(params.id) ? params.id[0] : params.id;
+export default async function Page({ params }: PageParams) {
+  const resolvedParams = await params;
+  const aiBotId = Array.isArray(resolvedParams.id)
+    ? resolvedParams.id[0]
+    : resolvedParams.id;
 
   return <ClientAiAgentProfilePage aiBotId={aiBotId} />;
 }

--- a/src/app/admin/profile/user/[id]/page.tsx
+++ b/src/app/admin/profile/user/[id]/page.tsx
@@ -1,13 +1,16 @@
 import ClientUserProfilePage from "./ClientUserProfilePage";
 
 type PageParams = {
-  params: {
+  params: Promise<{
     id: string | string[];
-  };
+  }>;
 };
 
-export default function Page({ params }: PageParams) {
-  const profileId = Array.isArray(params.id) ? params.id[0] : params.id;
+export default async function Page({ params }: PageParams) {
+  const resolvedParams = await params;
+  const profileId = Array.isArray(resolvedParams.id)
+    ? resolvedParams.id[0]
+    : resolvedParams.id;
 
   return <ClientUserProfilePage profileId={profileId} />;
 }


### PR DESCRIPTION
## Summary
- await dynamic route params in the admin user profile page
- await dynamic route params in the admin ai-agent profile page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dadb6202988333a02727c18aaef6aa