### PR TITLE
Fix MessageLike chat typing

### DIFF
--- a/src/stores/ChatStore.ts
+++ b/src/stores/ChatStore.ts
@@ -510,7 +510,7 @@ type ChatListItem = ChatDTO & {
   latestMessage?: MessageDTO | null;
 };
 
-type MessageLike = MessageDTO & {
+type MessageLike = Omit<MessageDTO, "chat"> & {
   chat?: { _id?: string } | string;
 };
 


### PR DESCRIPTION
## Summary
- adjust the MessageLike helper type to omit the original chat field before defining the flexible shape
- ensure runtime checks against incoming chat identifiers do not encounter a never-typed property

## Testing
- npm run build *(fails: module-not-found errors for axios/query-string and remote font downloads in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dadd094de08333a3771108c836cb58