### PR TITLE
Wrap admin chat page with Suspense

### DIFF
--- a/src/app/admin/chat/page.tsx
+++ b/src/app/admin/chat/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import AppShell from '@/components/AppShell';
 import ChatAvatar from '@/components/chats/ChatAvatar';
@@ -61,6 +61,25 @@ function PinnedMessagesSection({ messages, onUnpin }: { messages: MessageDTO[]; 
 }
 
 export default function ChatPage() {
+  return (
+    <Suspense fallback={<ChatPageFallback />}>
+      <ChatPageContent />
+    </Suspense>
+  );
+}
+
+function ChatPageFallback() {
+  return (
+    <AppShell>
+      <div className="flex h-full min-h-0 flex-col items-center justify-center gap-4 p-6 text-sm text-white/60">
+        <GradientOrbs />
+        <p>Loading chat…</p>
+      </div>
+    </AppShell>
+  );
+}
+
+function ChatPageContent() {
   const searchParams = useSearchParams();
   const chatId = searchParams.get('chatId');
   const { chatStore, authStore, onlineStore } = useRootStore();


### PR DESCRIPTION
## Summary
- wrap the admin chat page content in a Suspense boundary to support useSearchParams
- add a minimal loading fallback while the client-side params resolve

## Testing
- npm run build *(fails: missing dependencies such as axios in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daeab724708333ad32e86698aa2864