### PR TITLE
Wrap AppShell with Suspense for search params

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo } from 'react';
+import React, { Suspense, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -30,7 +30,7 @@ type AppShellProps = {
     sidebarCollapsed?: number; // ширина свернутого меню (px)
 };
 
-export default function AppShell({
+function AppShellContent({
     children,
     sidebarWidth = 240,
     sidebarCollapsed = 80,
@@ -394,6 +394,14 @@ export default function AppShell({
             )}
             <AuthPopupContainer />
         </div>
+    );
+}
+
+export default function AppShell(props: AppShellProps) {
+    return (
+        <Suspense fallback={null}>
+            <AppShellContent {...props} />
+        </Suspense>
     );
 }
 


### PR DESCRIPTION
## Summary
- wrap the AppShell component tree in a Suspense boundary to support useSearchParams
- move the existing AppShell implementation into an internal AppShellContent component and render it through the boundary

## Testing
- npm run build *(fails: Module not found: Can't resolve 'axios'; next/font unable to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68daebed7f908333a4b06fa7f901b2be