### PR TITLE
Handle closing auth popups when clicking backdrop

### DIFF
--- a/src/components/AuthPopup.tsx
+++ b/src/components/AuthPopup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import Image from 'next/image';
 import { Button } from '@/components/ui/Button';
@@ -122,8 +123,12 @@ export default function AuthPopup({
   }, [open, onClose]);
 
   // Клик по фону
-  const backdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) onClose();
+  const handleBackdropMouseDown = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (!dialogRef.current) return;
+
+    if (!dialogRef.current.contains(event.target as Node)) {
+      onClose();
+    }
   };
 
 
@@ -148,7 +153,7 @@ export default function AuthPopup({
       {open && (
         <motion.div
           className="fixed inset-0 z-50 flex items-center justify-center"
-          onMouseDown={backdropClick}
+          onMouseDown={handleBackdropMouseDown}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/src/components/EmailAuthPopup.tsx
+++ b/src/components/EmailAuthPopup.tsx
@@ -54,7 +54,9 @@ export default function EmailAuthPopup({ open, onBack, onClose, onSuccess }: Ema
   }, [open, onClose]);
 
   const handleBackdropClick = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
+    if (!dialogRef.current) return;
+
+    if (!dialogRef.current.contains(event.target as Node)) {
       onClose();
     }
   };


### PR DESCRIPTION
## Summary
- allow the main auth popup to close when clicking on the darkened backdrop
- mirror the same backdrop click handling for the email auth popup so it also closes correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ded228c3388333bd7ae1b249c757c5