### PR TITLE
Replace relationship preference with profession field

### DIFF
--- a/src/components/profile/edit/EditProfileDialog.tsx
+++ b/src/components/profile/edit/EditProfileDialog.tsx
@@ -8,7 +8,7 @@ import HeroRow from "./overview/HeroRow";
 import NameField from "./overview/NameField";
 import GenderGroup from "./overview/GenderGroup";
 import IntroField from "./overview/IntroField";
-import RelationshipField from "./overview/RelationshipField";
+import ProfessionField from "./overview/ProfessionField";
 import Notice from "./overview/Notice";
 import FormActions from "./overview/FormActions";
 import { useRootStore, useStoreData } from "@/stores/StoreProvider";
@@ -27,7 +27,7 @@ type Props = {
 export default function EditProfileDialog({ open, profile, onClose, onSave }: Props) {
   const { profileStore } = useRootStore();
   const genderOptions = useStoreData(profileStore, (store) => store.genderOptions);
-  const relationshipOptions = useStoreData(profileStore, (store) => store.relationshipOptions);
+  const professionOptions = useStoreData(profileStore, (store) => store.professionOptions);
 
   const [formState, setFormState] = useState<MyProfileDTO>(profile);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -155,13 +155,13 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
     }
   };
 
-  const relationshipChoices = useMemo(() => {
-    const baseOptions = [...relationshipOptions];
+  const professionChoices = useMemo(() => {
+    const baseOptions = [...professionOptions];
     if (formState.profession && !baseOptions.includes(formState.profession)) {
       baseOptions.push(formState.profession);
     }
     return baseOptions;
-  }, [relationshipOptions, formState.profession]);
+  }, [professionOptions, formState.profession]);
 
   return (
     <ModalShell open={open} onBackdrop={onClose}>
@@ -198,10 +198,10 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
             onChange={(val) => setFormState((s) => ({ ...s, userBio: val }))}
           />
 
-          <RelationshipField
-            value={formState.profession || relationshipChoices[0] || ""}
+          <ProfessionField
+            value={formState.profession || professionChoices[0] || ""}
             onChange={(val) => setFormState((s) => ({ ...s, profession: val }))}
-            options={relationshipChoices}
+            options={professionChoices}
           />
 
           <Notice />

--- a/src/components/profile/edit/overview/ProfessionField.tsx
+++ b/src/components/profile/edit/overview/ProfessionField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-export default function RelationshipField({
+export default function ProfessionField({
   value,
   onChange,
   options,
@@ -12,7 +12,7 @@ export default function RelationshipField({
   return (
     <label className="block space-y-2">
       <span className="text-xs font-medium uppercase tracking-wide text-neutral-400">
-        Relationship Preference
+        Profession
       </span>
       <div className="relative">
         <select

--- a/src/helpers/data/profile.ts
+++ b/src/helpers/data/profile.ts
@@ -3,11 +3,12 @@ export const genderOptions = [
   { value: "FEMALE", label: "Female" },
 ] as const;
 
-export const relationshipOptions: string[] = [
-  "View your relationship preference",
-  "Open to exploring",
-  "Looking for long-term",
-  "Here for friendship",
+export const professionOptions: string[] = [
+  "Выберите ваш род занятий",
+  "Обучаюсь",
+  "Студент",
+  "Работаю",
+  "Запускаю собственный проект",
 ] as const;
 
 
@@ -30,7 +31,7 @@ export const initialProfile = {
     userName: "Vadim Stepanov",
     gender: "MALE",
     intro: "AI product designer exploring the edges of digital companions.",
-    relationshipPreference: "View your relationship preference",
+    profession: "Выберите ваш род занятий",
 };
 
 

--- a/src/helpers/types/profile.ts
+++ b/src/helpers/types/profile.ts
@@ -51,5 +51,5 @@ export type EditableProfile = {
   userName: string;
   gender: string;
   intro: string;
-  relationshipPreference: string;
+  profession: string;
 };

--- a/src/stores/ProfileStore.ts
+++ b/src/stores/ProfileStore.ts
@@ -12,7 +12,7 @@ import {
   milestones,
   genderLabels,
   genderOptions as defaultGenderOptions,
-  relationshipOptions as defaultRelationshipOptions,
+  professionOptions as defaultProfessionOptions,
 } from '@/helpers/data/profile';
 
 export type PublicProfile = {
@@ -51,7 +51,7 @@ export class ProfileStore extends BaseStore {
   milestones = [...milestones];
   genderLabels = { ...genderLabels };
   genderOptions = [...defaultGenderOptions];
-  relationshipOptions = [...defaultRelationshipOptions];
+  professionOptions = [...defaultProfessionOptions];
 
   constructor(root: RootStore) {
     super();


### PR DESCRIPTION
## Summary
- rename the profile edit field from relationship preference to profession
- refresh the selectable options with the requested profession-related choices
- update profile data helpers and store defaults to align with the new profession field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dede1424b88333b99d9b0a369c1a3f