### PR TITLE
Fix mobile image upload inputs

### DIFF
--- a/src/components/ai-agent-create/IdentityStep.tsx
+++ b/src/components/ai-agent-create/IdentityStep.tsx
@@ -51,7 +51,7 @@ export default function IdentityStep({
               <Upload className="size-8 text-white/40" />
             )}
           </div>
-          <label className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-white/70 transition hover:border-violet-400/60 hover:bg-violet-500/10">
+          <label className="relative flex flex-1 cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-white/70 transition hover:border-violet-400/60 hover:bg-violet-500/10">
             <Upload className="size-5 text-violet-300" />
             <span className="font-medium text-white">
               {t("admin.create.identity.upload", "Upload image")}
@@ -59,7 +59,12 @@ export default function IdentityStep({
             <span className="text-xs text-white/60">
               {t("admin.create.identity.uploadHint", "PNG, JPG up to 5MB")}
             </span>
-            <input type="file" accept="image/*" className="hidden" onChange={onAvatarChange} />
+            <input
+              type="file"
+              accept="image/*"
+              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              onChange={onAvatarChange}
+            />
           </label>
         </div>
       </div>

--- a/src/components/ai-agent-create/MediaKitStep.tsx
+++ b/src/components/ai-agent-create/MediaKitStep.tsx
@@ -33,7 +33,7 @@ export default function MediaKitStep({
       </div>
 
       <div className="rounded-3xl border border-dashed border-white/15 bg-neutral-900/60 p-6 text-center text-sm text-white/70">
-        <label className="flex cursor-pointer flex-col items-center justify-center gap-3">
+        <label className="relative flex cursor-pointer flex-col items-center justify-center gap-3">
           <ImagePlus className="size-6 text-violet-300" />
           <span className="font-medium text-white">
             {t("admin.create.media.upload", "Upload gallery")}
@@ -44,7 +44,13 @@ export default function MediaKitStep({
               "Drop multiple images or pick from your library",
             )}
           </span>
-          <input type="file" accept="image/*" multiple className="hidden" onChange={onAdd} />
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            onChange={onAdd}
+          />
         </label>
       </div>
 

--- a/src/components/ai-agent/edit/EditAiAgentDialog.tsx
+++ b/src/components/ai-agent/edit/EditAiAgentDialog.tsx
@@ -478,7 +478,9 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
             </h3>
 
             <div className="rounded-3xl border border-dashed border-white/15 bg-white/[0.04] p-6 text-center text-sm text-white/70">
-              <label className={`flex cursor-pointer flex-col items-center justify-center gap-3 ${!canUploadPhotos ? "pointer-events-none opacity-50" : ""}`}>
+              <label
+                className={`relative flex cursor-pointer flex-col items-center justify-center gap-3 ${!canUploadPhotos ? "pointer-events-none opacity-50" : ""}`}
+              >
                 <ImagePlus className="size-6 text-violet-300" />
                 <span className="font-medium text-white">Upload gallery</span>
                 <span className="text-xs text-white/60">Drop multiple images or pick from your library</span>
@@ -486,7 +488,7 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
                   type="file"
                   accept="image/*"
                   multiple
-                  className="hidden"
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                   disabled={!canUploadPhotos}
                   onChange={handleGalleryUpload}
                 />

--- a/src/components/profile/edit/overview/HeroRow.tsx
+++ b/src/components/profile/edit/overview/HeroRow.tsx
@@ -56,7 +56,7 @@ export default function HeroRow({
             ref={inputRef}
             type="file"
             accept="image/*"
-            className="hidden"
+            className="sr-only"
             onChange={handleFileChange}
           />
 


### PR DESCRIPTION
## Summary
- ensure avatar and gallery upload inputs remain interactable on mobile browsers by using visually hidden styles instead of display none

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dee13d3de08333b8e57694686acb37