### PR TITLE
Localize edit profile dialog header

### DIFF
--- a/src/components/profile/edit/overview/DialogHeader.tsx
+++ b/src/components/profile/edit/overview/DialogHeader.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { Button } from "@/components/ui/Button";
+import { useTranslations } from "@/localization/TranslationProvider";
 
 export default function DialogHeader({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslations();
+
   return (
     <div className="flex items-center justify-between px-6 pb-4 pt-6 sm:px-8">
-      <h2 className="text-xl font-semibold sm:text-2xl">Edit Profile</h2>
+      <h2 className="text-xl font-semibold sm:text-2xl">
+        {t("admin.profile.my.editDialog.title", "Edit Profile")}
+      </h2>
       <Button
         type="button"
         onClick={onClose}
         variant="frostedIconCompact"
-        aria-label="Close"
+        aria-label={t("admin.profile.my.editDialog.closeAria", "Close")}
       >
         <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" d="M6 6l12 12M18 6L6 18" />

--- a/src/localization/dictionaries/ru.ts
+++ b/src/localization/dictionaries/ru.ts
@@ -91,6 +91,8 @@ registerTranslations('ru', {
   'admin.profile.my.sidebar.title': 'Фильтр AI-агентов',
   'admin.profile.my.sidebar.description': 'Выберите, показывать ли собственные работы или агентов, на которых вы подписаны.',
   'admin.profile.my.editButton': 'Редактировать профиль',
+  'admin.profile.my.editDialog.title': 'Редактирование профиля',
+  'admin.profile.my.editDialog.closeAria': 'Закрыть окно редактирования',
   'admin.profile.card.connections': 'Связи',
   'admin.profile.card.followers': 'Подписчики',
   'admin.profile.card.following': 'Подписки',


### PR DESCRIPTION
## Summary
- use the translation provider for the edit profile dialog header text and close button label
- add Russian translations for the new dialog title and aria label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dee8bca76c8333a8376a8f245bff17