### PR TITLE
Fix mobile image uploads for AI agents

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -53,12 +53,13 @@ export default function CreateAiAgentPage() {
 
   const handleAvatarChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0] ?? null;
-    aiBotStore.setAvatar(file);
+    void aiBotStore.setAvatar(file);
+    event.currentTarget.value = '';
   };
 
   const handleGalleryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
-    aiBotStore.addGalleryItems(files);
+    void aiBotStore.addGalleryItems(files);
     event.currentTarget.value = '';
   };
 

--- a/src/components/ai-agent/edit/EditAiAgentDialog.tsx
+++ b/src/components/ai-agent/edit/EditAiAgentDialog.tsx
@@ -15,6 +15,7 @@ import type { AiBotDTO } from "@/helpers/types/dtos/AiBotDto";
 import { getUserAvatar } from "@/helpers/utils/user";
 import type { AiBotUpdatePayload } from "@/services/profile/ProfileService";
 import { categoryOptions } from "@/helpers/data/agent-create";
+import { createImagePreview, revokeIfNeeded } from "@/helpers/utils/agent-create";
 
 const fieldLabelClasses =
   "flex items-center justify-between text-xs font-medium uppercase tracking-wide text-neutral-400";
@@ -93,7 +94,7 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
     setAvatarPreview(avatar);
 
     if (tempUrlRef.current) {
-      URL.revokeObjectURL(tempUrlRef.current);
+      revokeIfNeeded(tempUrlRef.current);
       tempUrlRef.current = null;
     }
   }, [open, aiAgent, botDetails]);
@@ -101,26 +102,33 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
   useEffect(() => {
     return () => {
       if (tempUrlRef.current) {
-        URL.revokeObjectURL(tempUrlRef.current);
+        revokeIfNeeded(tempUrlRef.current);
+        tempUrlRef.current = null;
       }
     };
   }, []);
 
-  const handleAvatarSelect = (file: File) => {
+  const handleAvatarSelect = async (file: File) => {
     if (tempUrlRef.current) {
-      URL.revokeObjectURL(tempUrlRef.current);
+      revokeIfNeeded(tempUrlRef.current);
+      tempUrlRef.current = null;
     }
 
-    const objectUrl = URL.createObjectURL(file);
-    tempUrlRef.current = objectUrl;
-
-    setAvatarFile(file);
-    setAvatarPreview(objectUrl);
+    try {
+      const preview = await createImagePreview(file);
+      if (preview.startsWith("blob:")) {
+        tempUrlRef.current = preview;
+      }
+      setAvatarFile(file);
+      setAvatarPreview(preview);
+    } catch (error) {
+      console.error("Failed to prepare avatar preview", error);
+    }
   };
 
   const handleAvatarRemove = () => {
     if (tempUrlRef.current) {
-      URL.revokeObjectURL(tempUrlRef.current);
+      revokeIfNeeded(tempUrlRef.current);
       tempUrlRef.current = null;
     }
 

--- a/src/components/profile/edit/overview/HeroRow.tsx
+++ b/src/components/profile/edit/overview/HeroRow.tsx
@@ -6,7 +6,7 @@ import { ChangeEvent, useRef } from "react";
 type Props = {
   userName?: string;
   avatarUrl?: string | null;
-  onAvatarSelect?: (file: File) => void;
+  onAvatarSelect?: (file: File) => void | Promise<void>;
   onAvatarRemove?: () => void;
   canRemoveAvatar?: boolean;
   description?: string;
@@ -25,7 +25,7 @@ export default function HeroRow({
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file && onAvatarSelect) {
-      onAvatarSelect(file);
+      void onAvatarSelect(file);
     }
 
     // allow selecting the same file again

--- a/src/helpers/utils/agent-create.ts
+++ b/src/helpers/utils/agent-create.ts
@@ -1,10 +1,48 @@
 import { GalleryItem } from "@/helpers/types/agent-create";
 
+const BLOB_URL_PREFIX = "blob:";
 
 export function revokeIfNeeded(url?: string | null) {
-  if (url) URL.revokeObjectURL(url);
+  if (!url || !url.startsWith(BLOB_URL_PREFIX)) {
+    return;
+  }
+
+  URL.revokeObjectURL(url);
 }
 
 export function revokeGallery(items: GalleryItem[]) {
-  items.forEach((i) => URL.revokeObjectURL(i.preview));
+  items.forEach((item) => revokeIfNeeded(item.preview));
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+
+      reject(new Error("Unexpected reader result"));
+    };
+
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read file"));
+    };
+
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function createImagePreview(file: File): Promise<string> {
+  if (typeof URL !== "undefined" && typeof URL.createObjectURL === "function") {
+    try {
+      return URL.createObjectURL(file);
+    } catch (error) {
+      console.warn("Falling back to FileReader for preview", error);
+    }
+  }
+
+  return readFileAsDataUrl(file);
 }


### PR DESCRIPTION
## Summary
- add a resilient image preview helper that falls back to FileReader on mobile and safely revokes blob URLs
- update AI bot creation and editing flows to await preview generation, reset file inputs, and support async avatar selection
- align shared profile editors with the new helper so avatar uploads work reliably on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deeb33034483338e3b1804c6440ad9