### PR TITLE
feat: improve mobile image uploads

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ChangeEvent } from 'react';
 import { useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { AlertCircle, CheckCircle2, Sparkles } from 'lucide-react';
@@ -51,24 +50,14 @@ export default function CreateAiAgentPage() {
 
   useEffect(() => () => aiBotStore.dispose(), [aiBotStore]);
 
-  const handleAvatarChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const input = event.currentTarget;
-    const file = input.files?.[0] ?? null;
-
+  const handleAvatarChange = (files: File[]) => {
+    const file = files[0] ?? null;
     const upload = aiBotStore.setAvatar(file);
-    upload.finally(() => {
-      input.value = '';
-    });
+    void upload;
   };
 
-  const handleGalleryChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const input = event.currentTarget;
-    const files = Array.from(input.files ?? []);
-
-    const upload = aiBotStore.addGalleryItems(files);
-    upload.finally(() => {
-      input.value = '';
-    });
+  const handleGalleryChange = (files: File[]) => {
+    void aiBotStore.addGalleryItems(files);
   };
 
   const removeGalleryItem = (id: string) => {

--- a/src/components/ai-agent-create/IdentityStep.tsx
+++ b/src/components/ai-agent-create/IdentityStep.tsx
@@ -4,13 +4,14 @@
 import { Upload } from "lucide-react";
 import { FormState } from "../../helpers/types/agent-create";
 import { useTranslations } from "@/localization/TranslationProvider";
+import { useImageUploader } from "@/helpers/hooks/useImageUploader";
 
 type IdentityForm = Pick<FormState, "firstName" | "lastName">;
 
 type IdentityStepProps = {
   form: IdentityForm;
   avatarPreview: string | null;
-  onAvatarChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAvatarChange: (files: File[]) => void;
   onChange: <K extends keyof IdentityForm>(field: K, value: IdentityForm[K]) => void;
 };
 
@@ -21,6 +22,10 @@ export default function IdentityStep({
   onChange,
 }: IdentityStepProps) {
   const { t } = useTranslations();
+  const { getRootProps, getInputProps, isDragActive } = useImageUploader({
+    onFiles: onAvatarChange,
+    enableCameraCapture: true,
+  });
   return (
     <div className="space-y-6">
       <div>
@@ -51,7 +56,13 @@ export default function IdentityStep({
               <Upload className="size-8 text-white/40" />
             )}
           </div>
-          <label className="relative flex flex-1 cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-white/70 transition hover:border-violet-400/60 hover:bg-violet-500/10">
+          <div
+            {...getRootProps({
+              className: `relative flex flex-1 cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border border-dashed bg-white/5 p-6 text-center text-sm text-white/70 transition hover:border-violet-400/60 hover:bg-violet-500/10 ${
+                isDragActive ? "border-violet-400/60 bg-violet-500/10" : "border-white/20"
+              }`,
+            })}
+          >
             <Upload className="size-5 text-violet-300" />
             <span className="font-medium text-white">
               {t("admin.create.identity.upload", "Upload image")}
@@ -60,12 +71,11 @@ export default function IdentityStep({
               {t("admin.create.identity.uploadHint", "PNG, JPG up to 5MB")}
             </span>
             <input
-              type="file"
-              accept="image/*"
-              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-              onChange={onAvatarChange}
+              {...getInputProps({
+                className: "absolute inset-0 h-full w-full cursor-pointer opacity-0",
+              })}
             />
-          </label>
+          </div>
         </div>
       </div>
 

--- a/src/components/ai-agent-create/MediaKitStep.tsx
+++ b/src/components/ai-agent-create/MediaKitStep.tsx
@@ -5,6 +5,7 @@ import { ImagePlus, X } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { GalleryItem } from "../../helpers/types/agent-create";
 import { useTranslations } from "@/localization/TranslationProvider";
+import { useImageUploader } from "@/helpers/hooks/useImageUploader";
 
 export default function MediaKitStep({
   gallery,
@@ -14,10 +15,19 @@ export default function MediaKitStep({
 }: {
   gallery: GalleryItem[];
   maxItems: number;
-  onAdd: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAdd: (files: File[]) => void;
   onRemove: (id: string) => void;
 }) {
   const { t } = useTranslations();
+  const remainingSlots = Math.max(0, maxItems - gallery.length);
+  const canUpload = remainingSlots > 0;
+  const { getRootProps, getInputProps, isDragActive } = useImageUploader({
+    onFiles: onAdd,
+    multiple: true,
+    maxFiles: remainingSlots,
+    enableCameraCapture: true,
+    disableClick: !canUpload,
+  });
   return (
     <div className="space-y-6">
       <div>
@@ -32,8 +42,14 @@ export default function MediaKitStep({
         </p>
       </div>
 
-      <div className="rounded-3xl border border-dashed border-white/15 bg-neutral-900/60 p-6 text-center text-sm text-white/70">
-        <label className="relative flex cursor-pointer flex-col items-center justify-center gap-3">
+      <div
+        {...getRootProps({
+          className: `relative rounded-3xl border border-dashed bg-neutral-900/60 p-6 text-center text-sm text-white/70 ${
+            canUpload ? "cursor-pointer" : "pointer-events-none opacity-60"
+          } ${isDragActive ? "border-violet-400/60 bg-violet-500/10" : "border-white/15"}`,
+        })}
+      >
+        <div className="relative flex flex-col items-center justify-center gap-3">
           <ImagePlus className="size-6 text-violet-300" />
           <span className="font-medium text-white">
             {t("admin.create.media.upload", "Upload gallery")}
@@ -44,14 +60,13 @@ export default function MediaKitStep({
               "Drop multiple images or pick from your library",
             )}
           </span>
-          <input
-            type="file"
-            accept="image/*"
-            multiple
-            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-            onChange={onAdd}
-          />
-        </label>
+        </div>
+        <input
+          {...getInputProps({
+            className: "absolute inset-0 h-full w-full cursor-pointer opacity-0",
+            disabled: !canUpload,
+          })}
+        />
       </div>
 
       {gallery.length >= maxItems && (

--- a/src/helpers/hooks/useImageUploader.ts
+++ b/src/helpers/hooks/useImageUploader.ts
@@ -1,0 +1,182 @@
+import { useCallback, useRef, useState } from "react";
+import type {
+  ChangeEvent,
+  ComponentPropsWithoutRef,
+  DragEvent,
+  MouseEvent,
+  MutableRefObject,
+} from "react";
+
+type UseImageUploaderOptions = {
+  onFiles: (files: File[]) => void;
+  multiple?: boolean;
+  maxFiles?: number;
+  accept?: string;
+  enableCameraCapture?: boolean;
+  disableClick?: boolean;
+};
+
+type RefCallback = MutableRefObject<HTMLInputElement | null> | ((instance: HTMLInputElement | null) => void);
+
+type GetRootProps = (
+  props?: ComponentPropsWithoutRef<"div">,
+) => ComponentPropsWithoutRef<"div">;
+
+type GetInputProps = (
+  props?: ComponentPropsWithoutRef<"input"> & { ref?: RefCallback },
+) => ComponentPropsWithoutRef<"input"> & { ref: (instance: HTMLInputElement | null) => void };
+
+export function useImageUploader({
+  onFiles,
+  multiple = false,
+  maxFiles,
+  accept = "image/*",
+  enableCameraCapture = true,
+  disableClick = false,
+}: UseImageUploaderOptions) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const dragCounter = useRef(0);
+  const [isDragActive, setIsDragActive] = useState(false);
+
+  const processFiles = useCallback(
+    (fileList: FileList | null | undefined) => {
+      if (!fileList) return;
+      const collected = Array.from(fileList);
+      if (!collected.length) return;
+
+      let limited = collected;
+      if (maxFiles !== undefined) {
+        limited = limited.slice(0, maxFiles);
+      }
+      if (!multiple && limited.length > 1) {
+        limited = [limited[0]];
+      }
+      if (!limited.length) return;
+      onFiles(limited);
+    },
+    [maxFiles, multiple, onFiles],
+  );
+
+  const open = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      processFiles(event.currentTarget.files);
+      event.currentTarget.value = "";
+    },
+    [processFiles],
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      dragCounter.current = 0;
+      setIsDragActive(false);
+      processFiles(event.dataTransfer?.files);
+    },
+    [processFiles],
+  );
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const handleDragEnter = useCallback((event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragCounter.current += 1;
+    setIsDragActive(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragCounter.current = Math.max(0, dragCounter.current - 1);
+    if (dragCounter.current === 0) {
+      setIsDragActive(false);
+    }
+  }, []);
+
+  const mergeRefs = useCallback((node: HTMLInputElement | null, ref?: RefCallback) => {
+    if (typeof ref === "function") {
+      ref(node);
+    } else if (ref) {
+      (ref as MutableRefObject<HTMLInputElement | null>).current = node;
+    }
+  }, []);
+
+  const getInputProps: GetInputProps = useCallback(
+    (props = {}) => {
+      const { ref: forwardedRef, onChange, capture, ...rest } = props;
+      return {
+        ...rest,
+        ref: (instance: HTMLInputElement | null) => {
+          inputRef.current = instance;
+          mergeRefs(instance, forwardedRef);
+        },
+        type: "file",
+        accept,
+        multiple,
+        capture: enableCameraCapture ? (capture ?? "environment") : capture,
+        onChange: (event: ChangeEvent<HTMLInputElement>) => {
+          handleChange(event);
+          onChange?.(event);
+        },
+      };
+    },
+    [accept, enableCameraCapture, handleChange, mergeRefs, multiple],
+  );
+
+  const getRootProps: GetRootProps = useCallback(
+    (props = {}) => {
+      const {
+        onClick,
+        onDrop,
+        onDragOver: onDragOverProp,
+        onDragEnter: onDragEnterProp,
+        onDragLeave: onDragLeaveProp,
+        ...rest
+      } = props;
+      return {
+        ...rest,
+        onClick: (event: MouseEvent<HTMLElement>) => {
+          if (!disableClick) {
+            event.preventDefault();
+            open();
+          }
+          onClick?.(event);
+        },
+        onDrop: (event: DragEvent<HTMLElement>) => {
+          handleDrop(event);
+          onDrop?.(event);
+        },
+        onDragOver: (event: DragEvent<HTMLElement>) => {
+          handleDragOver(event);
+          onDragOverProp?.(event);
+        },
+        onDragEnter: (event: DragEvent<HTMLElement>) => {
+          handleDragEnter(event);
+          onDragEnterProp?.(event);
+        },
+        onDragLeave: (event: DragEvent<HTMLElement>) => {
+          handleDragLeave(event);
+          onDragLeaveProp?.(event);
+        },
+      };
+    },
+    [disableClick, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, open],
+  );
+
+  return {
+    getRootProps,
+    getInputProps,
+    open,
+    isDragActive,
+  };
+}
+
+export type ImageUploaderReturn = ReturnType<typeof useImageUploader>;


### PR DESCRIPTION
## Summary
- add a reusable image uploader hook that supports drag-and-drop and mobile camera capture
- replace file inputs in AI agent creation/editing and profile editor with the new uploader for reliable photo selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68def1fbbf9483338c1482e53aa0a0f5