### PR TITLE
Add profession field and enforce required agent creation inputs

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -189,7 +189,7 @@ export default function CreateAiAgentPage() {
             <div className="rounded-3xl border border-white/10 bg-neutral-900/80 p-6 shadow-[0_30px_80px_-50px_rgba(79,70,229,0.6)]">
               {step === 0 && (
                 <IdentityStep
-                  form={{ firstName: form.firstName, lastName: form.lastName }}
+                  form={{ firstName: form.firstName, lastName: form.lastName, profession: form.profession }}
                   avatarPreview={avatarPreview}
                   onAvatarChange={handleAvatarChange}
                   onChange={handleChange}

--- a/src/components/ai-agent-create/IdentityStep.tsx
+++ b/src/components/ai-agent-create/IdentityStep.tsx
@@ -5,7 +5,7 @@ import { Upload } from "lucide-react";
 import { FormState } from "../../helpers/types/agent-create";
 import { useTranslations } from "@/localization/TranslationProvider";
 
-type IdentityForm = Pick<FormState, "firstName" | "lastName">;
+type IdentityForm = Pick<FormState, "firstName" | "lastName" | "profession">;
 
 type IdentityStepProps = {
   form: IdentityForm;
@@ -75,6 +75,7 @@ export default function IdentityStep({
             value={form.firstName}
             onChange={(e) => onChange("firstName", e.target.value)}
             placeholder={t("admin.create.identity.firstNamePlaceholder", "aiAgent")}
+            required
             className="rounded-2xl border border-white/10 bg-neutral-900/80 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-violet-400 focus:outline-none"
           />
         </label>
@@ -84,6 +85,17 @@ export default function IdentityStep({
             value={form.lastName}
             onChange={(e) => onChange("lastName", e.target.value)}
             placeholder={t("admin.create.identity.lastNamePlaceholder", "Alpha")}
+            required
+            className="rounded-2xl border border-white/10 bg-neutral-900/80 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-violet-400 focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-white/70 sm:col-span-2">
+          {t("admin.create.identity.profession", "Profession")}
+          <input
+            value={form.profession}
+            onChange={(e) => onChange("profession", e.target.value)}
+            placeholder={t("admin.create.identity.professionPlaceholder", "Product designer")}
+            required
             className="rounded-2xl border border-white/10 bg-neutral-900/80 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-violet-400 focus:outline-none"
           />
         </label>

--- a/src/components/ai-agent-create/PreviewSidebar.tsx
+++ b/src/components/ai-agent-create/PreviewSidebar.tsx
@@ -48,6 +48,9 @@ export default function PreviewSidebar({
                 " " +
                 (form.lastName || t("admin.create.preview.defaultLast", "agent"))}
             </p>
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              {form.profession || t("admin.create.preview.professionPlaceholder", "Profession")}
+            </p>
             <p className="max-h-20 overflow-hidden text-xs text-white/60">
               {form.description ||
                 t(

--- a/src/components/ai-agent-create/VoiceStoryStep.tsx
+++ b/src/components/ai-agent-create/VoiceStoryStep.tsx
@@ -37,6 +37,7 @@ export default function VoiceStoryStep({ form, onChange }: VoiceStoryStepProps) 
               "admin.create.voice.promptPlaceholder",
               "You are a strategic confidant who helps people reframe their challenges with empathy...",
             )}
+            required
             className="min-h-[140px] rounded-3xl border border-white/10 bg-neutral-900/80 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-violet-400 focus:outline-none"
           />
         </label>

--- a/src/components/ai-agent/edit/EditAiAgentDialog.tsx
+++ b/src/components/ai-agent/edit/EditAiAgentDialog.tsx
@@ -314,6 +314,7 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
                   }
                   placeholder="Enter how people will call your agent"
                   maxLength={24}
+                  required
                   className={inputClasses}
                 />
               </label>
@@ -331,10 +332,29 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
                   }
                   placeholder="Optional last name or identifier"
                   maxLength={24}
+                  required
                   className={inputClasses}
                 />
               </label>
             </div>
+
+            <label className="space-y-2">
+              <div className={fieldLabelClasses}>
+                <span>Profession</span>
+                <span>{charCounters.profession}/24</span>
+              </div>
+              <input
+                type="text"
+                value={formState.profession}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, profession: event.target.value.slice(0, 24) }))
+                }
+                placeholder="What role does your agent embody?"
+                maxLength={24}
+                required
+                className={inputClasses}
+              />
+            </label>
 
             <label className="space-y-2">
               <div className={fieldLabelClasses}>
@@ -454,6 +474,7 @@ export default function EditAiAgentDialog({ open, aiAgent, onClose }: Props) {
                 }
                 rows={5}
                 placeholder="You are a strategic confidant who helps people reframe their challenges with empathy..."
+                required
                 className="min-h-[140px] w-full rounded-3xl border border-white/10 bg-white/[0.06] px-4 py-3 text-sm text-white placeholder:text-neutral-500 focus:border-white/40 focus:outline-none"
               />
             </label>

--- a/src/helpers/types/agent-create.ts
+++ b/src/helpers/types/agent-create.ts
@@ -1,6 +1,7 @@
 export type FormState = {
   firstName: string;
   lastName: string;
+  profession: string;
   prompt: string;
   description: string;
   intro: string;

--- a/src/stores/AiBotStore.ts
+++ b/src/stores/AiBotStore.ts
@@ -25,6 +25,7 @@ export class AiBotStore extends BaseStore {
   form: FormState = {
     firstName: '',
     lastName: '',
+    profession: '',
     prompt: '',
     description: '',
     intro: '',
@@ -79,18 +80,15 @@ export class AiBotStore extends BaseStore {
         return Boolean(
           this.form.firstName.trim() &&
           this.form.lastName.trim() &&
+          this.form.profession.trim() &&
           (this.avatar !== null || this.avatarPreview !== null),
         );
       case 1:
-        return this.form.categories.length > 0 && this.form.usefulness.length > 0;
+        return true;
       case 2:
-        return Boolean(
-          this.form.prompt.trim() &&
-          this.form.description.trim() &&
-          this.form.intro.trim(),
-        );
+        return Boolean(this.form.prompt.trim());
       default:
-        return this.gallery.length > 0;
+        return true;
     }
   }
 
@@ -170,6 +168,7 @@ export class AiBotStore extends BaseStore {
     this.form = {
       firstName: '',
       lastName: '',
+      profession: '',
       prompt: '',
       description: '',
       intro: '',
@@ -398,7 +397,11 @@ export class AiBotStore extends BaseStore {
     const formData = new FormData();
     formData.append('name', this.form.firstName.trim());
     formData.append('lastname', this.form.lastName.trim());
-    formData.append('userBio', this.form.description.trim());
+    formData.append('profession', this.form.profession.trim());
+    const userBio = this.form.description.trim();
+    if (userBio) {
+      formData.append('userBio', userBio);
+    }
     formData.append('aiPrompt', this.form.prompt.trim());
     const intro = this.form.intro.trim();
     if (intro) {


### PR DESCRIPTION
## Summary
- add a required profession field to the AI agent identity step, preview, and edit dialog
- relax creation flow validation so only avatar, name, surname, profession, and system prompt are required
- include profession in creation payloads and show it in the live preview

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1057d251483339f0ecbc19a8b1307