### PR TITLE
Allow manual profession entry in profile editor

### DIFF
--- a/src/components/profile/edit/EditProfileDialog.tsx
+++ b/src/components/profile/edit/EditProfileDialog.tsx
@@ -155,14 +155,6 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
     }
   };
 
-  const professionChoices = useMemo(() => {
-    const baseOptions = [...professionOptions];
-    if (formState.profession && !baseOptions.includes(formState.profession)) {
-      baseOptions.push(formState.profession);
-    }
-    return baseOptions;
-  }, [professionOptions, formState.profession]);
-
   return (
     <ModalShell open={open} onBackdrop={onClose}>
       <form onSubmit={handleSubmit}>
@@ -199,9 +191,9 @@ export default function EditProfileDialog({ open, profile, onClose, onSave }: Pr
           />
 
           <ProfessionField
-            value={formState.profession || professionChoices[0] || ""}
+            value={formState.profession || ""}
             onChange={(val) => setFormState((s) => ({ ...s, profession: val }))}
-            options={professionChoices}
+            placeholder={professionOptions[0] || ""}
           />
 
           <Notice />

--- a/src/components/profile/edit/overview/ProfessionField.tsx
+++ b/src/components/profile/edit/overview/ProfessionField.tsx
@@ -3,39 +3,24 @@
 export default function ProfessionField({
   value,
   onChange,
-  options,
+  placeholder = "",
 }: {
   value: string;
   onChange: (val: string) => void;
-  options: readonly string[];
+  placeholder?: string;
 }) {
   return (
     <label className="block space-y-2">
       <span className="text-xs font-medium uppercase tracking-wide text-neutral-400">
         Profession
       </span>
-      <div className="relative">
-        <select
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full appearance-none rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-left text-base text-white focus:border-white/40 focus:outline-none"
-        >
-          {options.map((option) => (
-            <option key={option} value={option} className="bg-neutral-900 text-white">
-              {option}
-            </option>
-          ))}
-        </select>
-        <svg
-          viewBox="0 0 20 20"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={1.5}
-          className="pointer-events-none absolute right-4 top-1/2 size-4 -translate-y-1/2 text-neutral-400"
-        >
-          <path d="M6 8l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </div>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-left text-base text-white placeholder:text-neutral-500 focus:border-white/40 focus:outline-none"
+      />
     </label>
   );
 }


### PR DESCRIPTION
## Summary
- replace the profile editor profession dropdown with a free-form text input
- update the profession field component to accept a placeholder instead of a predefined options list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e40b52dbec8333b0acc0e0e12a5d91