### PR TITLE
Add copy link functionality to profile share buttons

### DIFF
--- a/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
+++ b/src/app/admin/profile/ai-agent/[id]/ClientAiAgentProfilePage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { ArrowLeft, Share2 } from "lucide-react";
 
 import AppShell from "@/components/AppShell";
@@ -23,6 +23,7 @@ import { useRootStore, useStoreData } from "@/stores/StoreProvider";
 import type { Highlight } from "@/helpers/types/ai-agent";
 import SessionVibe from "@/components/ai-agent/SessionVibe";
 import { useBreakpoint } from "@/helpers/hooks/useBreakpoint";
+import { useCopyLink } from "@/helpers/hooks/useCopyLink";
 import { useTranslations } from "@/localization/TranslationProvider";
 
 
@@ -34,9 +35,11 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
   const { routes, getProfile } = useAuthRoutes();
   const { aiBotStore, authStore, chatStore } = useRootStore();
   const router = useRouter();
+  const pathname = usePathname();
   const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
   const discoverRoute = routes.discover;
   const { t } = useTranslations();
+  const copyLink = useCopyLink();
 
   const aiBot = useStoreData(aiBotStore, (store) => store.selectAiBot);
   const isLoading = useStoreData(aiBotStore, (store) => store.isAiUserLoading);
@@ -152,6 +155,11 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
     router.push(discoverRoute);
   }, [router, discoverRoute]);
 
+  const handleShare = useCallback(() => {
+    if (!pathname) return;
+    void copyLink(pathname);
+  }, [copyLink, pathname]);
+
   return (
     <AppShell>
       <div className="relative min-h-screen overflow-y-auto bg-neutral-950 text-white">
@@ -176,6 +184,7 @@ export default function ClientAiAgentProfilePage({ aiBotId }: ClientAiAgentProfi
               )}
               <Button
                 type="button"
+                onClick={handleShare}
                 variant="frostedIcon"
                 aria-label={t("admin.profile.aiAgent.shareAria", "Share agent")}
               >

--- a/src/components/profile/HeaderActions.tsx
+++ b/src/components/profile/HeaderActions.tsx
@@ -1,45 +1,55 @@
 "use client";
 
+import { useCallback } from "react";
 import { ArrowLeft, Share2 } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { Button } from '@/components/ui/Button';
+import { usePathname, useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/Button";
 import { useBreakpoint } from "@/helpers/hooks/useBreakpoint";
+import { useCopyLink } from "@/helpers/hooks/useCopyLink";
 import MoreActionsMenu from "@/components/MoreActionsMenu";
 import { useTranslations } from "@/localization/TranslationProvider";
 
-
 export default function HeaderActions({ onEdit }: { onEdit: () => void }) {
-    const router = useRouter();
-    const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
-    const { t } = useTranslations();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
+  const copyLink = useCopyLink();
+  const { t } = useTranslations();
 
-    return (
-        <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-                {isMdUp && (
-                    <Button
-                        type="button"
-                        onClick={() => router.back()}
-                        variant="frostedIcon"
-                        aria-label={t("admin.profile.common.backAria", "Go back")}
-                    >
-                        <ArrowLeft className="size-5" />
-                    </Button>
-                )}
-                <Button
-                    type="button"
-                    variant="frostedIcon"
-                    aria-label={t("admin.profile.common.shareAria", "Share")}
-                >
-                    <Share2 className="size-5" />
-                </Button>
-                <MoreActionsMenu mode="self" />
-            </div>
-            <div className="flex items-center gap-3">
-                <Button onClick={onEdit} variant="solidWhitePill">
-                    {t("admin.profile.my.editButton", "Edit Profile")}
-                </Button>
-            </div>
-        </div>
-    );
+  const handleShare = useCallback(() => {
+    if (!pathname) return;
+    void copyLink(pathname);
+  }, [copyLink, pathname]);
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex items-center gap-2">
+        {isMdUp && (
+          <Button
+            type="button"
+            onClick={() => router.back()}
+            variant="frostedIcon"
+            aria-label={t("admin.profile.common.backAria", "Go back")}
+          >
+            <ArrowLeft className="size-5" />
+          </Button>
+        )}
+        <Button
+          type="button"
+          onClick={handleShare}
+          variant="frostedIcon"
+          aria-label={t("admin.profile.common.shareAria", "Share")}
+        >
+          <Share2 className="size-5" />
+        </Button>
+        <MoreActionsMenu mode="self" />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button onClick={onEdit} variant="solidWhitePill">
+          {t("admin.profile.my.editButton", "Edit Profile")}
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/user/HeaderBar.tsx
+++ b/src/components/user/HeaderBar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useCallback } from "react";
 import { ArrowLeft, Check, Share2, Sparkles } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
 import { useBreakpoint } from "@/helpers/hooks/useBreakpoint";
+import { useCopyLink } from "@/helpers/hooks/useCopyLink";
 import MoreActionsMenu from "@/components/MoreActionsMenu";
 import { useTranslations } from "@/localization/TranslationProvider";
 
@@ -35,7 +37,14 @@ export default function HeaderBar({
   const ButtonIcon = isFollowing ? Check : Sparkles;
   const buttonVariant = isFollowing ? "frostedPill" : "subscribe";
   const router = useRouter();
+  const pathname = usePathname();
   const { isMdUp } = useBreakpoint(); // md (≥768px) и выше
+  const copyLink = useCopyLink();
+
+  const handleShare = useCallback(() => {
+    if (!pathname) return;
+    void copyLink(pathname);
+  }, [copyLink, pathname]);
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-4">
@@ -52,6 +61,7 @@ export default function HeaderBar({
         )}
         <Button
           type="button"
+          onClick={handleShare}
           variant="frostedIcon"
           aria-label={t("admin.profile.common.shareAria", "Share")}
         >

--- a/src/helpers/hooks/useCopyLink.ts
+++ b/src/helpers/hooks/useCopyLink.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { useRootStore } from "@/stores/StoreProvider";
+import { useTranslations } from "@/localization/TranslationProvider";
+
+const ensureAbsoluteUrl = (href: string) => {
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    return href;
+  }
+
+  if (typeof window === "undefined") {
+    return href;
+  }
+
+  return `${window.location.origin}${href.startsWith("/") ? href : `/${href}`}`;
+};
+
+const copyTextToClipboard = async (text: string) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+};
+
+export function useCopyLink() {
+  const { uiStore } = useRootStore();
+  const { t } = useTranslations();
+
+  return useCallback(
+    async (href: string) => {
+      if (typeof window === "undefined") {
+        return false;
+      }
+
+      const absoluteUrl = ensureAbsoluteUrl(href);
+
+      try {
+        const didCopy = await copyTextToClipboard(absoluteUrl);
+
+        if (didCopy) {
+          uiStore.showSnackbar(
+            t("common.copyLink.success", "Link copied to clipboard"),
+            "success",
+          );
+          return true;
+        }
+
+        uiStore.showSnackbar(
+          t("common.copyLink.error", "Unable to copy link. Please try again."),
+          "error",
+        );
+        return false;
+      } catch (error) {
+        console.error("Failed to copy link", error);
+        uiStore.showSnackbar(
+          t("common.copyLink.error", "Unable to copy link. Please try again."),
+          "error",
+        );
+        return false;
+      }
+    },
+    [t, uiStore],
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a reusable `useCopyLink` hook that copies URLs and surfaces snackbar feedback
- connect share actions on my profile, user profile, and AI agent pages to copy the current link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e505b66bd88333897e523191c5dbb9