### PR TITLE
Add documentation landing page with shared config

### DIFF
--- a/src/app/docs/[slug]/page.tsx
+++ b/src/app/docs/[slug]/page.tsx
@@ -1,60 +1,14 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import type { ComponentType } from "react";
 
-import {
-  ChildSafetyStandards,
-  DeleteAccountInfo,
-  PrivacyPolicy,
-  TermsOfUse,
-} from "..";
-
-interface DocEntry {
-  Component: ComponentType;
-  metadata: Metadata;
-}
-
-const DOCS = {
-  "privacy-policy": {
-    Component: PrivacyPolicy,
-    metadata: {
-      title: "AiPair | Privacy Policy",
-      description:
-        "Review AiPair's privacy policy to understand how your data is collected, used, and protected.",
-    },
-  },
-  "terms-of-use": {
-    Component: TermsOfUse,
-    metadata: {
-      title: "AiPair | Terms of Use",
-      description:
-        "Read the AiPair terms of use to learn about the rules and responsibilities when using the platform.",
-    },
-  },
-  "child-safety-standards": {
-    Component: ChildSafetyStandards,
-    metadata: {
-      title: "AiPair | Child Safety Standards",
-      description:
-        "Understand the measures AiPair takes to keep children safe and how to report potential issues.",
-    },
-  },
-  "delete-account": {
-    Component: DeleteAccountInfo,
-    metadata: {
-      title: "AiPair | Delete Account Information",
-      description:
-        "Learn how to delete your AiPair account and what happens to your data once the process is complete.",
-    },
-  },
-} satisfies Record<string, DocEntry>;
+import { DOCS, DOCS_BY_SLUG, type DocSlug } from "../docs.config";
 
 export function generateStaticParams() {
-  return Object.keys(DOCS).map((slug) => ({ slug }));
+  return DOCS.map(({ slug }) => ({ slug }));
 }
 
 export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
-  const entry = DOCS[params.slug as keyof typeof DOCS];
+  const entry = DOCS_BY_SLUG[params.slug as DocSlug];
 
   if (!entry) {
     return {
@@ -68,7 +22,7 @@ export function generateMetadata({ params }: { params: { slug: string } }): Meta
 }
 
 export default function DocPage({ params }: { params: { slug: string } }) {
-  const entry = DOCS[params.slug as keyof typeof DOCS];
+  const entry = DOCS_BY_SLUG[params.slug as DocSlug];
 
   if (!entry) {
     notFound();

--- a/src/app/docs/docs.config.ts
+++ b/src/app/docs/docs.config.ts
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import type { ComponentType } from "react";
+
+import {
+  ChildSafetyStandards,
+  DeleteAccountInfo,
+  PrivacyPolicy,
+  TermsOfUse,
+} from ".";
+
+export type DocSlug =
+  | "privacy-policy"
+  | "terms-of-use"
+  | "child-safety-standards"
+  | "delete-account";
+
+export interface DocConfigEntry {
+  slug: DocSlug;
+  name: string;
+  summary: string;
+  Component: ComponentType;
+  metadata: Metadata;
+}
+
+export const DOCS = [
+  {
+    slug: "privacy-policy",
+    name: "Privacy Policy",
+    summary:
+      "Understand how AiPair collects, uses, and protects your personal data across the platform.",
+    Component: PrivacyPolicy,
+    metadata: {
+      title: "AiPair | Privacy Policy",
+      description:
+        "Review AiPair's privacy policy to understand how your data is collected, used, and protected.",
+    },
+  },
+  {
+    slug: "terms-of-use",
+    name: "Terms of Use",
+    summary:
+      "Learn about the rules and responsibilities that apply when using the AiPair platform.",
+    Component: TermsOfUse,
+    metadata: {
+      title: "AiPair | Terms of Use",
+      description:
+        "Read the AiPair terms of use to learn about the rules and responsibilities when using the platform.",
+    },
+  },
+  {
+    slug: "child-safety-standards",
+    name: "Child Safety Standards",
+    summary:
+      "See the safeguards AiPair follows to keep young users safe and respond to potential issues.",
+    Component: ChildSafetyStandards,
+    metadata: {
+      title: "AiPair | Child Safety Standards",
+      description:
+        "Understand the measures AiPair takes to keep children safe and how to report potential issues.",
+    },
+  },
+  {
+    slug: "delete-account",
+    name: "Delete Account Information",
+    summary:
+      "Find out how to permanently delete your AiPair account and what happens to your data afterwards.",
+    Component: DeleteAccountInfo,
+    metadata: {
+      title: "AiPair | Delete Account Information",
+      description:
+        "Learn how to delete your AiPair account and what happens to your data once the process is complete.",
+    },
+  },
+] satisfies DocConfigEntry[];
+
+export const DOCS_BY_SLUG = DOCS.reduce<Record<DocSlug, DocConfigEntry>>((acc, doc) => {
+  acc[doc.slug] = doc;
+  return acc;
+}, {} as Record<DocSlug, DocConfigEntry>);

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BookOpen, FileText, ShieldCheck, UserMinus, Users } from "lucide-react";
+import type { JSX } from "react";
+
+import { DOCS, type DocSlug } from "./docs.config";
+
+const iconBySlug: Record<DocSlug, JSX.Element> = {
+  "privacy-policy": <ShieldCheck className="h-6 w-6" aria-hidden="true" />,
+  "terms-of-use": <FileText className="h-6 w-6" aria-hidden="true" />,
+  "child-safety-standards": <Users className="h-6 w-6" aria-hidden="true" />,
+  "delete-account": <UserMinus className="h-6 w-6" aria-hidden="true" />,
+};
+
+export const metadata: Metadata = {
+  title: "AiPair | Документы и политики",
+  description:
+    "Найдите основные документы AiPair: правила использования, политику конфиденциальности и стандарты безопасности.",
+};
+
+export default function DocsLandingPage() {
+  return (
+    <main className="relative isolate min-h-screen overflow-hidden bg-[#070611] text-white">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-[10%] top-[-10%] h-72 w-72 rounded-full bg-[#6f2da8]/40 blur-3xl" />
+        <div className="absolute right-[-15%] top-[25%] h-80 w-80 rounded-full bg-fuchsia-500/30 blur-[140px]" />
+        <div className="absolute bottom-[-20%] left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-indigo-500/20 blur-[160px]" />
+      </div>
+
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 py-20 sm:px-10 lg:px-12">
+        <header className="mx-auto max-w-3xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm font-medium text-white/80">
+            <BookOpen className="h-4 w-4" aria-hidden="true" />
+            Документы AiPair
+          </span>
+          <h1 className="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Всё, что нужно знать об использовании AiPair
+          </h1>
+          <p className="mt-4 text-lg leading-relaxed text-white/70">
+            Ознакомьтесь с политиками сервиса, требованиями к безопасности и инструкциями по управлению аккаунтом. Мы
+            собрали ключевые документы, чтобы вы всегда могли быстро найти ответы на важные вопросы.
+          </p>
+        </header>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          {DOCS.map((doc) => (
+            <Link
+              key={doc.slug}
+              href={`/docs/${doc.slug}`}
+              className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_45px_-25px_rgba(111,45,168,0.6)] transition hover:border-[#b794f6]/40 hover:bg-white/10"
+            >
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#6f2da8]/20 text-[#c4b5fd] transition group-hover:scale-105">
+                  {iconBySlug[doc.slug]}
+                </div>
+                <h2 className="text-xl font-semibold text-white">{doc.name}</h2>
+              </div>
+
+              <p className="mt-4 flex-1 text-base text-white/70">{doc.summary}</p>
+
+              <span className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-[#c4b5fd] transition group-hover:translate-x-1">
+                Читать документ
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14" />
+                  <path d="m12 5 7 7-7 7" />
+                </svg>
+              </span>
+            </Link>
+          ))}
+        </div>
+
+        <footer className="rounded-2xl border border-white/10 bg-white/5 p-8 text-center text-sm text-white/60">
+          Нужна дополнительная информация? Напишите нам на{' '}
+          <a className="font-medium text-[#c4b5fd] underline decoration-transparent transition hover:decoration-[#c4b5fd]" href="mailto:hello@aipair.app">
+            hello@aipair.app
+          </a>{' '}
+          — мы всегда готовы помочь.
+        </footer>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a shared documentation config that provides metadata and React components for each policy page
- reuse the shared config inside the dynamic docs route for cleaner slug handling
- create a styled /docs landing page that presents quick links to every available document

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffc3dec9988333b81d55e34c6fc2bb